### PR TITLE
activity delegate

### DIFF
--- a/navi/src/main/java/com/trello/navi/NaviActivity.java
+++ b/navi/src/main/java/com/trello/navi/NaviActivity.java
@@ -1,5 +1,6 @@
 package com.trello.navi;
 
+import com.trello.navi.internal.NaviActivityDelegate;
 import com.trello.navi.model.BundleBundle;
 import rx.functions.Action0;
 import rx.functions.Action1;
@@ -40,4 +41,6 @@ public interface NaviActivity {
   void addRestoreInstanceStateListener(Action1<BundleBundle> listener);
 
   void removeRestoreInstanceStateListener(Action1<BundleBundle> listener);
+
+  void addDelegate(NaviActivityDelegate delegate);
 }

--- a/navi/src/main/java/com/trello/navi/component/AbstractNaviActivity.java
+++ b/navi/src/main/java/com/trello/navi/component/AbstractNaviActivity.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.os.Bundle;
 import android.os.PersistableBundle;
 import com.trello.navi.NaviActivity;
+import com.trello.navi.internal.NaviActivityDelegate;
 import com.trello.navi.internal.BaseNaviActivity;
 import com.trello.navi.model.BundleBundle;
 import rx.functions.Action0;
@@ -160,6 +161,10 @@ public abstract class AbstractNaviActivity extends Activity implements NaviActiv
 
   @Override public void removeRestoreInstanceStateListener(Action1<BundleBundle> listener) {
     base.removeRestoreInstanceStateListener(listener);
+  }
+
+  @Override public void addDelegate(NaviActivityDelegate delegate) {
+    base.addDelegate(delegate);
   }
 
   @Override protected void onRestoreInstanceState(Bundle savedInstanceState) {

--- a/navi/src/main/java/com/trello/navi/component/support/AbstractNaviActivity.java
+++ b/navi/src/main/java/com/trello/navi/component/support/AbstractNaviActivity.java
@@ -4,6 +4,7 @@ import android.os.Bundle;
 import android.os.PersistableBundle;
 import android.support.v7.app.AppCompatActivity;
 import com.trello.navi.NaviActivity;
+import com.trello.navi.internal.NaviActivityDelegate;
 import com.trello.navi.internal.BaseNaviActivity;
 import com.trello.navi.model.BundleBundle;
 import rx.functions.Action0;
@@ -160,6 +161,10 @@ public abstract class AbstractNaviActivity extends AppCompatActivity implements 
 
   @Override public void removeRestoreInstanceStateListener(Action1<BundleBundle> listener) {
     base.removeRestoreInstanceStateListener(listener);
+  }
+
+  @Override public void addDelegate(NaviActivityDelegate delegate) {
+    base.addDelegate(delegate);
   }
 
   @Override protected void onRestoreInstanceState(Bundle savedInstanceState) {

--- a/navi/src/main/java/com/trello/navi/internal/BaseNaviActivity.java
+++ b/navi/src/main/java/com/trello/navi/internal/BaseNaviActivity.java
@@ -32,6 +32,8 @@ public final class BaseNaviActivity implements NaviActivity {
   private List<Action1<BundleBundle>> restoreInstanceStateListeners;
   private List<Action1<BundleBundle>> saveInstanceStateListeners;
 
+  private List<NaviActivityDelegate> activityDelegates;
+
   ////////////////////////////////////////////////////////////////////////////
   // onCreate
 
@@ -53,11 +55,21 @@ public final class BaseNaviActivity implements NaviActivity {
     if (createListeners != null) {
       emitAction1(createListeners, new BundleBundle(savedInstanceState));
     }
+    if (activityDelegates != null) {
+      for (int i = 0; i < activityDelegates.size(); i++) {
+        activityDelegates.get(i).onCreate(new BundleBundle(savedInstanceState));
+      }
+    }
   }
 
   public void onCreate(Bundle savedInstanceState, PersistableBundle persistentState) {
     if (createListeners != null) {
       emitAction1(createListeners, new BundleBundle(savedInstanceState, persistentState));
+    }
+    if (activityDelegates != null) {
+      for (int i = 0; i < activityDelegates.size(); i++) {
+        activityDelegates.get(i).onCreate(new BundleBundle(savedInstanceState, persistentState));
+      }
     }
   }
 
@@ -82,6 +94,11 @@ public final class BaseNaviActivity implements NaviActivity {
     if (startListeners != null) {
       emitAction0(startListeners);
     }
+    if (activityDelegates != null) {
+      for (int i = 0; i < activityDelegates.size(); i++) {
+        activityDelegates.get(i).onStart();
+      }
+    }
   }
 
   ////////////////////////////////////////////////////////////////////////////
@@ -104,6 +121,11 @@ public final class BaseNaviActivity implements NaviActivity {
   public void onResume() {
     if (resumeListeners != null) {
       emitAction0(resumeListeners);
+    }
+    if (activityDelegates != null) {
+      for (int i = 0; i < activityDelegates.size(); i++) {
+        activityDelegates.get(i).onResume();
+      }
     }
   }
 
@@ -128,6 +150,11 @@ public final class BaseNaviActivity implements NaviActivity {
     if (pauseListeners != null) {
       emitAction0(pauseListeners);
     }
+    if (activityDelegates != null) {
+      for (int i = 0; i < activityDelegates.size(); i++) {
+        activityDelegates.get(i).onPause();
+      }
+    }
   }
 
   ////////////////////////////////////////////////////////////////////////////
@@ -150,6 +177,11 @@ public final class BaseNaviActivity implements NaviActivity {
   public void onStop() {
     if (stopListeners != null) {
       emitAction0(stopListeners);
+    }
+    if (activityDelegates != null) {
+      for (int i = 0; i < activityDelegates.size(); i++) {
+        activityDelegates.get(i).onStop();
+      }
     }
   }
 
@@ -174,6 +206,11 @@ public final class BaseNaviActivity implements NaviActivity {
     if (destroyListeners != null) {
       emitAction0(destroyListeners);
     }
+    if (activityDelegates != null) {
+      for (int i = 0; i < activityDelegates.size(); i++) {
+        activityDelegates.get(i).onDestroy();
+      }
+    }
   }
 
   ////////////////////////////////////////////////////////////////////////////
@@ -196,6 +233,11 @@ public final class BaseNaviActivity implements NaviActivity {
   public void onRestart() {
     if (restartListeners != null) {
       emitAction0(restartListeners);
+    }
+    if (activityDelegates != null) {
+      for (int i = 0; i < activityDelegates.size(); i++) {
+        activityDelegates.get(i).onRestart();
+      }
     }
   }
 
@@ -220,11 +262,22 @@ public final class BaseNaviActivity implements NaviActivity {
     if (saveInstanceStateListeners != null) {
       emitAction1(saveInstanceStateListeners, new BundleBundle(outState));
     }
+    if (activityDelegates != null) {
+      for (int i = 0; i < activityDelegates.size(); i++) {
+        activityDelegates.get(i).onSaveInstanceState(new BundleBundle(outState));
+      }
+    }
   }
 
   public void onSaveInstanceState(Bundle outState, PersistableBundle outPersistentState) {
     if (saveInstanceStateListeners != null) {
       emitAction1(saveInstanceStateListeners, new BundleBundle(outState, outPersistentState));
+    }
+    if (activityDelegates != null) {
+      for (int i = 0; i < activityDelegates.size(); i++) {
+        activityDelegates.get(i)
+            .onSaveInstanceState(new BundleBundle(outState, outPersistentState));
+      }
     }
   }
 
@@ -249,6 +302,11 @@ public final class BaseNaviActivity implements NaviActivity {
     if (restoreInstanceStateListeners != null) {
       emitAction1(restoreInstanceStateListeners, new BundleBundle(savedInstanceState));
     }
+    if (activityDelegates != null) {
+      for (int i = 0; i < activityDelegates.size(); i++) {
+        activityDelegates.get(i).onRestoreInstanceState(new BundleBundle(savedInstanceState));
+      }
+    }
   }
 
   public void onRestoreInstanceState(Bundle savedInstanceState, PersistableBundle persistentState) {
@@ -256,5 +314,18 @@ public final class BaseNaviActivity implements NaviActivity {
       emitAction1(restoreInstanceStateListeners,
           new BundleBundle(savedInstanceState, persistentState));
     }
+    if (activityDelegates != null) {
+      for (int i = 0; i < activityDelegates.size(); i++) {
+        activityDelegates.get(i)
+            .onRestoreInstanceState(new BundleBundle(savedInstanceState, persistentState));
+      }
+    }
+  }
+
+  public void addDelegate(NaviActivityDelegate delegate) {
+    if (activityDelegates == null) {
+      activityDelegates = new ArrayList<>(Constants.DEFAULT_LIST_SIZE);
+    }
+    activityDelegates.add(delegate);
   }
 }

--- a/navi/src/main/java/com/trello/navi/internal/NaviActivityDelegate.java
+++ b/navi/src/main/java/com/trello/navi/internal/NaviActivityDelegate.java
@@ -1,0 +1,45 @@
+package com.trello.navi.internal;
+
+import android.support.annotation.Nullable;
+import com.trello.navi.model.BundleBundle;
+
+/**
+ * Forwards multiple Activity lifecycle methods. Useful for libraries requiring multiple lifecycle
+ * events
+ */
+public class NaviActivityDelegate {
+
+  public void onCreate(@Nullable BundleBundle savedInstanceState) {
+
+  }
+
+  public void onRestoreInstanceState(BundleBundle savedInstanceState) {
+
+  }
+
+  public void onStart() {
+
+  }
+
+  public void onRestart() {
+
+  }
+
+  public void onResume() {
+  }
+
+  public void onSaveInstanceState(BundleBundle outState) {
+  }
+
+  public void onPause() {
+
+  }
+
+  public void onStop() {
+
+  }
+
+  public void onDestroy() {
+
+  }
+}

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -20,6 +20,16 @@
         <category android:name="android.intent.category.LAUNCHER"/>
       </intent-filter>
     </activity>
+    <activity
+        android:name=".delegate.SampleBaseActivity"
+        android:label="@string/activity_delegate"
+        >
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN"/>
+
+        <category android:name="android.intent.category.LAUNCHER"/>
+      </intent-filter>
+    </activity>
   </application>
 
 </manifest>

--- a/sample/src/main/java/com/trello/navi/sample/delegate/AnotherLibraryDelegate.java
+++ b/sample/src/main/java/com/trello/navi/sample/delegate/AnotherLibraryDelegate.java
@@ -1,0 +1,25 @@
+package com.trello.navi.sample.delegate;
+
+import android.support.annotation.Nullable;
+import android.util.Log;
+import com.trello.navi.internal.NaviActivityDelegate;
+import com.trello.navi.model.BundleBundle;
+
+public class AnotherLibraryDelegate extends NaviActivityDelegate {
+  private static final String TAG = AnotherLibraryDelegate.class.getSimpleName();
+
+  @Override public void onCreate(@Nullable BundleBundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    if (savedInstanceState != null) Log.v(TAG, "I've got created");
+  }
+
+  @Override public void onResume() {
+    super.onResume();
+    Log.v(TAG, "I'm running");
+  }
+
+  @Override public void onPause() {
+    super.onPause();
+    Log.v(TAG, "I've got paused");
+  }
+}

--- a/sample/src/main/java/com/trello/navi/sample/delegate/GpsLibraryDelegate.java
+++ b/sample/src/main/java/com/trello/navi/sample/delegate/GpsLibraryDelegate.java
@@ -1,0 +1,18 @@
+package com.trello.navi.sample.delegate;
+
+import android.util.Log;
+import com.trello.navi.internal.NaviActivityDelegate;
+
+public class GpsLibraryDelegate extends NaviActivityDelegate {
+  private static final String TAG = GpsLibraryDelegate.class.getSimpleName();
+
+  @Override public void onResume() {
+    super.onResume();
+    Log.v(TAG, "starting GPS");
+  }
+
+  @Override public void onPause() {
+    super.onPause();
+    Log.v(TAG, "stopping GPS");
+  }
+}

--- a/sample/src/main/java/com/trello/navi/sample/delegate/SampleBaseActivity.java
+++ b/sample/src/main/java/com/trello/navi/sample/delegate/SampleBaseActivity.java
@@ -1,0 +1,27 @@
+package com.trello.navi.sample.delegate;
+
+import android.os.Bundle;
+import android.util.Log;
+import com.trello.navi.component.support.AbstractNaviActivity;
+import com.trello.navi.sample.R;
+
+/**
+ * Example how to add multiple delegates to an Activity.
+ */
+public class SampleBaseActivity extends AbstractNaviActivity {
+
+  public SampleBaseActivity() {
+    addDelegate(new AnotherLibraryDelegate());
+    addDelegate(new GpsLibraryDelegate());
+  }
+
+  @Override protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.main);
+  }
+
+  @Override protected void onStart() {
+    super.onStart();
+    Log.v(SampleBaseActivity.class.getSimpleName(), "started SampleBaseActivity");
+  }
+}

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
   <string name="app_name">Navi</string>
+  <string name="activity_delegate">Navi Delegate</string>
   <string name="action_settings">Settings</string>
 </resources>


### PR DESCRIPTION
added a delegate for activities to forward activity lifecycle methods

Easier to use when requiring multiple lifecycle methods instead of registering for multiple events. It's not that efficient because the delegate callbacks get always called even if not implemented.


- [ ] missing delegate for fragments