### PR TITLE
Add NaviPlugin (a collection of listeners)

### DIFF
--- a/navi/src/main/java/com/trello/navi/ActivityNaviPlugin.java
+++ b/navi/src/main/java/com/trello/navi/ActivityNaviPlugin.java
@@ -1,0 +1,162 @@
+package com.trello.navi;
+
+import android.content.Intent;
+import android.content.res.Configuration;
+import android.os.Bundle;
+import com.trello.navi.internal.HandledEvents;
+import com.trello.navi.internal.NaviPlugin;
+import com.trello.navi.model.ActivityResult;
+import com.trello.navi.model.BundleBundle;
+import com.trello.navi.model.RequestPermissionsResult;
+
+public class ActivityNaviPlugin extends NaviPlugin {
+  public ActivityNaviPlugin() {
+    super(HandledEvents.ACTIVITY_EVENTS);
+  }
+
+  public <T> void onEvent(Event<T> event, T data) {
+    //TODO not sure if pure if-else implementation would be faster
+    final Event.Type type = event.type();
+    switch (type) {
+      case CREATE:
+        if (event.equals(Event.CREATE_PERSISTABLE)) {
+          onCreate((BundleBundle) data);
+        } else {
+          onCreate((Bundle) data);
+        }
+        break;
+      case START:
+        onStart();
+        break;
+      case RESUME:
+        onResume();
+        break;
+      case PAUSE:
+        onPause();
+        break;
+      case STOP:
+        onStop();
+        break;
+      case DESTROY:
+        onDestroy();
+        break;
+      case SAVE_INSTANCE_STATE:
+        if (event.equals(Event.SAVE_INSTANCE_STATE_PERSISTABLE)) {
+          onSaveInstanceState((BundleBundle) data);
+        } else {
+          onSaveInstanceState((Bundle) data);
+        }
+        break;
+      case CONFIGURATION_CHANGED:
+        onConfigurationChanged((Configuration) data);
+        break;
+      case ACTIVITY_RESULT:
+        onActivityResult((ActivityResult) data);
+        break;
+      case REQUEST_PERMISSIONS_RESULT:
+        onRequestPermissionsResult((RequestPermissionsResult) data);
+        break;
+      case RESTART:
+        onRestart();
+        break;
+      case RESTORE_INSTANCE_STATE:
+        if (event.equals(Event.RESTORE_INSTANCE_STATE_PERSISTABLE)) {
+          onRestoreInstanceState((BundleBundle) data);
+        } else {
+          onRestoreInstanceState((Bundle) data);
+        }
+        break;
+      case NEW_INTENT:
+        onNewIntent((Intent) data);
+        break;
+      case BACK_PRESSED:
+        onBackPressed();
+        break;
+      case ATTACHED_TO_WINDOW:
+        onAttachedToWindow();
+        break;
+      case DETACHED_FROM_WINDOW:
+        onDetachedFromWindow();
+        break;
+      default:
+        // not handled
+        break;
+    }
+  }
+
+  protected void onCreate(BundleBundle bundle) {
+
+  }
+
+  protected void onCreate(Bundle bundle) {
+
+  }
+
+  protected void onStart() {
+
+  }
+
+  protected void onResume() {
+
+  }
+
+  protected void onPause() {
+
+  }
+
+  protected void onStop() {
+
+  }
+
+  protected void onDestroy() {
+
+  }
+
+  protected void onRestart() {
+
+  }
+
+  protected void onSaveInstanceState(Bundle bundle) {
+
+  }
+
+  protected void onSaveInstanceState(BundleBundle bundle) {
+
+  }
+
+  protected void onRestoreInstanceState(Bundle savedInstanceState) {
+
+  }
+
+  protected void onRestoreInstanceState(BundleBundle savedInstanceState) {
+
+  }
+
+  protected void onNewIntent(Intent intent) {
+
+  }
+
+  protected void onBackPressed() {
+
+  }
+
+  protected void onAttachedToWindow() {
+
+  }
+
+  protected void onDetachedFromWindow() {
+
+  }
+
+  protected void onConfigurationChanged(Configuration newConfig) {
+
+  }
+
+  protected void onActivityResult(ActivityResult result) {
+
+  }
+
+  protected void onRequestPermissionsResult(RequestPermissionsResult result) {
+
+  }
+}

--- a/navi/src/main/java/com/trello/navi/FragmentNaviPlugin.java
+++ b/navi/src/main/java/com/trello/navi/FragmentNaviPlugin.java
@@ -1,0 +1,136 @@
+package com.trello.navi;
+
+import android.content.Context;
+import android.content.res.Configuration;
+import android.os.Bundle;
+import com.trello.navi.internal.HandledEvents;
+import com.trello.navi.internal.NaviPlugin;
+import com.trello.navi.model.ActivityResult;
+import com.trello.navi.model.RequestPermissionsResult;
+
+public class FragmentNaviPlugin extends NaviPlugin {
+  public FragmentNaviPlugin() {
+    super(HandledEvents.FRAGMENT_EVENTS);
+  }
+
+  @Override public <T> void onEvent(Event<T> event, T data) {
+    final Event.Type type = event.type();
+    switch (type) {
+      case CREATE:
+        onCreate((Bundle) data);
+        break;
+      case START:
+        onStart();
+        break;
+      case RESUME:
+        onResume();
+        break;
+      case PAUSE:
+        onPause();
+        break;
+      case STOP:
+        onStop();
+        break;
+      case DESTROY:
+        onDestroy();
+        break;
+      case SAVE_INSTANCE_STATE:
+        onSaveInstanceState((Bundle) data);
+        break;
+      case CONFIGURATION_CHANGED:
+        onConfigurationChanged((Configuration) data);
+        break;
+      case ACTIVITY_RESULT:
+        onActivityResult((ActivityResult) data);
+        break;
+      case REQUEST_PERMISSIONS_RESULT:
+        onRequestPermissionsResult((RequestPermissionsResult) data);
+        break;
+      case ATTACH:
+        onAttach((Context) data);
+        break;
+      case CREATE_VIEW:
+        onCreateView((Bundle) data);
+        break;
+      case ACTIVITY_CREATED:
+        onActivityCreated((Bundle) data);
+        break;
+      case VIEW_STATE_RESTORED:
+        onViewStateRestored((Bundle) data);
+        break;
+      case DESTROY_VIEW:
+        onDestroyView();
+        break;
+      case DETACH:
+        onDetach();
+        break;
+      default:
+        // not handled
+        break;
+    }
+  }
+
+  protected void onAttach(Context context) {
+
+  }
+
+  protected void onCreate(Bundle savedInstanceState) {
+
+  }
+
+  protected void onCreateView(Bundle savedInstanceState) {
+
+  }
+
+  protected void onActivityCreated(Bundle savedInstanceState) {
+
+  }
+
+  protected void onViewStateRestored(Bundle savedInstanceState) {
+
+  }
+
+  protected void onStart() {
+
+  }
+
+  protected void onResume() {
+
+  }
+
+  protected void onPause() {
+
+  }
+
+  protected void onStop() {
+
+  }
+
+  protected void onDestroyView() {
+
+  }
+
+  protected void onDestroy() {
+
+  }
+
+  protected void onDetach() {
+
+  }
+
+  protected void onSaveInstanceState(Bundle outState) {
+
+  }
+
+  protected void onConfigurationChanged(Configuration newConfig) {
+
+  }
+
+  protected void onActivityResult(ActivityResult activityResult) {
+
+  }
+
+  protected void onRequestPermissionsResult(RequestPermissionsResult requestPermissionsResult) {
+
+  }
+}

--- a/navi/src/main/java/com/trello/navi/NaviComponent.java
+++ b/navi/src/main/java/com/trello/navi/NaviComponent.java
@@ -1,5 +1,7 @@
 package com.trello.navi;
 
+import com.trello.navi.internal.NaviPlugin;
+
 /**
  * Represents an Android component (Activity, Fragment) that can have listeners.
  */
@@ -34,4 +36,8 @@ public interface NaviComponent {
    * @throws IllegalArgumentException if this component cannot handle the event
    */
   <T> void removeListener(Event<T> event, Listener<T> listener);
+
+  void addPlugin(NaviPlugin plugin);
+
+  void removePlugin(NaviPlugin plugin);
 }

--- a/navi/src/main/java/com/trello/navi/component/NaviActivity.java
+++ b/navi/src/main/java/com/trello/navi/component/NaviActivity.java
@@ -10,6 +10,7 @@ import com.trello.navi.Event;
 import com.trello.navi.Listener;
 import com.trello.navi.NaviComponent;
 import com.trello.navi.internal.NaviEmitter;
+import com.trello.navi.internal.NaviPlugin;
 
 public class NaviActivity extends Activity implements NaviComponent {
 
@@ -25,6 +26,14 @@ public class NaviActivity extends Activity implements NaviComponent {
 
   @Override public <T> void removeListener(Event<T> event, Listener<T> listener) {
     base.removeListener(event, listener);
+  }
+
+  @Override public void addPlugin(NaviPlugin plugin) {
+    base.addPlugin(plugin);
+  }
+
+  @Override public void removePlugin(NaviPlugin plugin) {
+    base.removePlugin(plugin);
   }
 
   @Override protected void onCreate(Bundle savedInstanceState) {

--- a/navi/src/main/java/com/trello/navi/component/NaviDialogFragment.java
+++ b/navi/src/main/java/com/trello/navi/component/NaviDialogFragment.java
@@ -15,6 +15,7 @@ import com.trello.navi.Event;
 import com.trello.navi.Listener;
 import com.trello.navi.NaviComponent;
 import com.trello.navi.internal.NaviEmitter;
+import com.trello.navi.internal.NaviPlugin;
 
 public class NaviDialogFragment extends DialogFragment implements NaviComponent {
 
@@ -30,6 +31,14 @@ public class NaviDialogFragment extends DialogFragment implements NaviComponent 
 
   @Override public <T> void removeListener(Event<T> event, Listener<T> listener) {
     base.removeListener(event, listener);
+  }
+
+  @Override public void addPlugin(NaviPlugin plugin) {
+    base.addPlugin(plugin);
+  }
+
+  @Override public void removePlugin(NaviPlugin plugin) {
+    base.removePlugin(plugin);
   }
 
   @Override public void onAttach(Activity activity) {

--- a/navi/src/main/java/com/trello/navi/component/NaviFragment.java
+++ b/navi/src/main/java/com/trello/navi/component/NaviFragment.java
@@ -15,6 +15,7 @@ import com.trello.navi.Event;
 import com.trello.navi.Listener;
 import com.trello.navi.NaviComponent;
 import com.trello.navi.internal.NaviEmitter;
+import com.trello.navi.internal.NaviPlugin;
 
 public class NaviFragment extends Fragment implements NaviComponent {
 
@@ -30,6 +31,14 @@ public class NaviFragment extends Fragment implements NaviComponent {
 
   @Override public <T> void removeListener(Event<T> event, Listener<T> listener) {
     base.removeListener(event, listener);
+  }
+
+  @Override public void addPlugin(NaviPlugin plugin) {
+    base.addPlugin(plugin);
+  }
+
+  @Override public void removePlugin(NaviPlugin plugin) {
+    base.removePlugin(plugin);
   }
 
   @Override public void onAttach(Activity activity) {

--- a/navi/src/main/java/com/trello/navi/component/support/NaviAppCompatActivity.java
+++ b/navi/src/main/java/com/trello/navi/component/support/NaviAppCompatActivity.java
@@ -10,6 +10,7 @@ import com.trello.navi.Event;
 import com.trello.navi.Listener;
 import com.trello.navi.NaviComponent;
 import com.trello.navi.internal.NaviEmitter;
+import com.trello.navi.internal.NaviPlugin;
 
 public class NaviAppCompatActivity extends AppCompatActivity implements NaviComponent {
 
@@ -25,6 +26,14 @@ public class NaviAppCompatActivity extends AppCompatActivity implements NaviComp
 
   @Override public <T> void removeListener(Event<T> event, Listener<T> listener) {
     base.removeListener(event, listener);
+  }
+
+  @Override public void addPlugin(NaviPlugin plugin) {
+    base.addPlugin(plugin);
+  }
+
+  @Override public void removePlugin(NaviPlugin plugin) {
+    base.removePlugin(plugin);
   }
 
   @Override protected void onCreate(Bundle savedInstanceState) {

--- a/navi/src/main/java/com/trello/navi/component/support/NaviDialogFragment.java
+++ b/navi/src/main/java/com/trello/navi/component/support/NaviDialogFragment.java
@@ -15,6 +15,7 @@ import com.trello.navi.Event;
 import com.trello.navi.Listener;
 import com.trello.navi.NaviComponent;
 import com.trello.navi.internal.NaviEmitter;
+import com.trello.navi.internal.NaviPlugin;
 
 public class NaviDialogFragment extends DialogFragment implements NaviComponent {
 
@@ -30,6 +31,14 @@ public class NaviDialogFragment extends DialogFragment implements NaviComponent 
 
   @Override public <T> void removeListener(Event<T> event, Listener<T> listener) {
     base.removeListener(event, listener);
+  }
+
+  @Override public void addPlugin(NaviPlugin plugin) {
+    base.addPlugin(plugin);
+  }
+
+  @Override public void removePlugin(NaviPlugin plugin) {
+    base.removePlugin(plugin);
   }
 
   @Override public void onAttach(Activity activity) {

--- a/navi/src/main/java/com/trello/navi/component/support/NaviFragment.java
+++ b/navi/src/main/java/com/trello/navi/component/support/NaviFragment.java
@@ -15,6 +15,7 @@ import com.trello.navi.Event;
 import com.trello.navi.Listener;
 import com.trello.navi.NaviComponent;
 import com.trello.navi.internal.NaviEmitter;
+import com.trello.navi.internal.NaviPlugin;
 
 public class NaviFragment extends Fragment implements NaviComponent {
 
@@ -30,6 +31,14 @@ public class NaviFragment extends Fragment implements NaviComponent {
 
   @Override public <T> void removeListener(Event<T> event, Listener<T> listener) {
     base.removeListener(event, listener);
+  }
+
+  @Override public void addPlugin(NaviPlugin plugin) {
+    base.addPlugin(plugin);
+  }
+
+  @Override public void removePlugin(NaviPlugin plugin) {
+    base.removePlugin(plugin);
   }
 
   @Override public void onAttach(Activity activity) {

--- a/navi/src/main/java/com/trello/navi/internal/HandledEvents.java
+++ b/navi/src/main/java/com/trello/navi/internal/HandledEvents.java
@@ -32,7 +32,7 @@ public final class HandledEvents {
           Event.REQUEST_PERMISSIONS_RESULT
       );
 
-  static final List<Event<?>> FRAGMENT_EVENTS =
+  public static final List<Event<?>> FRAGMENT_EVENTS =
       Arrays.asList(
           Event.ATTACH,
           Event.CREATE,

--- a/navi/src/main/java/com/trello/navi/internal/HandledEvents.java
+++ b/navi/src/main/java/com/trello/navi/internal/HandledEvents.java
@@ -7,9 +7,9 @@ import java.util.List;
 /**
  * A place to store a common list of handled events by activities and fragments
  */
-final class HandledEvents {
+public final class HandledEvents {
 
-  static final List<Event<?>> ACTIVITY_EVENTS =
+  public static final List<Event<?>> ACTIVITY_EVENTS =
       Arrays.asList(
           Event.CREATE,
           Event.CREATE_PERSISTABLE,

--- a/navi/src/main/java/com/trello/navi/internal/NaviPlugin.java
+++ b/navi/src/main/java/com/trello/navi/internal/NaviPlugin.java
@@ -1,0 +1,22 @@
+package com.trello.navi.internal;
+
+import com.trello.navi.Event;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+public abstract class NaviPlugin {
+
+  private final Set<Event<?>> events;
+
+  public NaviPlugin(Collection<Event<?>> events) {
+    this.events = Collections.unmodifiableSet(new HashSet<>(events));
+  }
+
+  public Set<Event<?>> getEvents() {
+    return events;
+  }
+
+  public abstract <T> void onEvent(Event<T> event, T data);
+}

--- a/navi/src/main/java/com/trello/navi/internal/NaviPlugin.java
+++ b/navi/src/main/java/com/trello/navi/internal/NaviPlugin.java
@@ -1,6 +1,7 @@
 package com.trello.navi.internal;
 
 import com.trello.navi.Event;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -11,7 +12,13 @@ public abstract class NaviPlugin {
   private final Set<Event<?>> events;
 
   public NaviPlugin(Collection<Event<?>> events) {
-    this.events = Collections.unmodifiableSet(new HashSet<>(events));
+    Set<Event<?>> set = new HashSet<>();
+    set.addAll(events);
+    this.events = Collections.unmodifiableSet(set);
+  }
+
+  public NaviPlugin(Event<?>... events) {
+    this(Arrays.asList(events));
   }
 
   public Set<Event<?>> getEvents() {

--- a/navi/src/test/java/com/trello/navi/NaviActivityPluginTest.java
+++ b/navi/src/test/java/com/trello/navi/NaviActivityPluginTest.java
@@ -16,36 +16,12 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-public class PluginTest {
+public class NaviActivityPluginTest {
 
   private final NaviEmitter emitter = NaviEmitter.createActivityEmitter();
-
-  @Test public void addRemovePlugin() {
-    NaviPlugin plugin = spy(new NaviPlugin(Event.START) {
-      @Override public <T> void onEvent(Event<T> event, T data) {
-
-      }
-    });
-    emitter.addPlugin(plugin);
-    verify(plugin).getEvents();
-
-    emitter.onStart();
-    verify(plugin).onEvent(Event.START, null);
-
-    emitter.removePlugin(plugin);
-    emitter.onStart();
-    verifyNoMoreInteractions(plugin);
-  }
-
-  @Test(expected = IllegalArgumentException.class) public void addWrongPlugin()
-      throws Exception {
-    NaviEmitter emitter = NaviEmitter.createFragmentEmitter();
-    ActivityNaviPlugin plugin = new ActivityNaviPlugin();
-    emitter.addPlugin(plugin);
-  }
+  private ActivityNaviPlugin plugin = spy(new ActivityNaviPlugin());
 
   @Test public void testOnCreate() throws Exception {
-    ActivityNaviPlugin plugin = spy(new ActivityNaviPlugin());
     emitter.addPlugin(plugin);
     verify(plugin).getEvents();
 
@@ -60,7 +36,6 @@ public class PluginTest {
   }
 
   @Test public void testOnCreatePersistable() throws Exception {
-    ActivityNaviPlugin plugin = spy(new ActivityNaviPlugin());
     emitter.addPlugin(plugin);
     verify(plugin).getEvents();
 
@@ -79,7 +54,6 @@ public class PluginTest {
   }
 
   @Test public void testOnStart() throws Exception {
-    ActivityNaviPlugin plugin = spy(new ActivityNaviPlugin());
     emitter.addPlugin(plugin);
     verify(plugin).getEvents();
 
@@ -93,7 +67,6 @@ public class PluginTest {
   }
 
   @Test public void testOnResume() throws Exception {
-    ActivityNaviPlugin plugin = spy(new ActivityNaviPlugin());
     emitter.addPlugin(plugin);
     verify(plugin).getEvents();
 
@@ -107,7 +80,6 @@ public class PluginTest {
   }
 
   @Test public void testOnPause() throws Exception {
-    ActivityNaviPlugin plugin = spy(new ActivityNaviPlugin());
     emitter.addPlugin(plugin);
     verify(plugin).getEvents();
 
@@ -121,7 +93,6 @@ public class PluginTest {
   }
 
   @Test public void testStop() throws Exception {
-    ActivityNaviPlugin plugin = spy(new ActivityNaviPlugin());
     emitter.addPlugin(plugin);
     verify(plugin).getEvents();
 
@@ -135,7 +106,6 @@ public class PluginTest {
   }
 
   @Test public void testOnDestroy() throws Exception {
-    ActivityNaviPlugin plugin = spy(new ActivityNaviPlugin());
     emitter.addPlugin(plugin);
     verify(plugin).getEvents();
 
@@ -149,7 +119,6 @@ public class PluginTest {
   }
 
   @Test public void testOnSaveInstanceState() throws Exception {
-    ActivityNaviPlugin plugin = spy(new ActivityNaviPlugin());
     emitter.addPlugin(plugin);
     verify(plugin).getEvents();
 
@@ -164,7 +133,6 @@ public class PluginTest {
   }
 
   @Test public void testOnSaveInstanceStatePersistable() throws Exception {
-    ActivityNaviPlugin plugin = spy(new ActivityNaviPlugin());
     emitter.addPlugin(plugin);
     verify(plugin).getEvents();
 
@@ -183,7 +151,6 @@ public class PluginTest {
   }
 
   @Test public void testOnConfigurationChanged() throws Exception {
-    ActivityNaviPlugin plugin = spy(new ActivityNaviPlugin());
     emitter.addPlugin(plugin);
     verify(plugin).getEvents();
 
@@ -198,7 +165,6 @@ public class PluginTest {
   }
 
   @Test public void testOnActivityResult() throws Exception {
-    ActivityNaviPlugin plugin = spy(new ActivityNaviPlugin());
     emitter.addPlugin(plugin);
     verify(plugin).getEvents();
 
@@ -214,7 +180,6 @@ public class PluginTest {
   }
 
   @Test public void testOnRequestPermissionResult() throws Exception {
-    ActivityNaviPlugin plugin = spy(new ActivityNaviPlugin());
     emitter.addPlugin(plugin);
     verify(plugin).getEvents();
 
@@ -232,7 +197,6 @@ public class PluginTest {
   }
 
   @Test public void testOnRestart() throws Exception {
-    ActivityNaviPlugin plugin = spy(new ActivityNaviPlugin());
     emitter.addPlugin(plugin);
     verify(plugin).getEvents();
 
@@ -246,7 +210,6 @@ public class PluginTest {
   }
 
   @Test public void testOnRestoreInstanceState() throws Exception {
-    ActivityNaviPlugin plugin = spy(new ActivityNaviPlugin());
     emitter.addPlugin(plugin);
     verify(plugin).getEvents();
 
@@ -261,7 +224,6 @@ public class PluginTest {
   }
 
   @Test public void testOnRestoreInstanceStatePersistable() throws Exception {
-    ActivityNaviPlugin plugin = spy(new ActivityNaviPlugin());
     emitter.addPlugin(plugin);
     verify(plugin).getEvents();
 
@@ -280,7 +242,6 @@ public class PluginTest {
   }
 
   @Test public void testOnNewIntent() throws Exception {
-    ActivityNaviPlugin plugin = spy(new ActivityNaviPlugin());
     emitter.addPlugin(plugin);
     verify(plugin).getEvents();
 
@@ -295,7 +256,6 @@ public class PluginTest {
   }
 
   @Test public void testOnBackPressed() throws Exception {
-    ActivityNaviPlugin plugin = spy(new ActivityNaviPlugin());
     emitter.addPlugin(plugin);
     verify(plugin).getEvents();
 
@@ -309,7 +269,6 @@ public class PluginTest {
   }
 
   @Test public void testOnAttachedToWindow() throws Exception {
-    ActivityNaviPlugin plugin = spy(new ActivityNaviPlugin());
     emitter.addPlugin(plugin);
     verify(plugin).getEvents();
 
@@ -323,7 +282,6 @@ public class PluginTest {
   }
 
   @Test public void testOnDetachedToWindow() throws Exception {
-    ActivityNaviPlugin plugin = spy(new ActivityNaviPlugin());
     emitter.addPlugin(plugin);
     verify(plugin).getEvents();
 

--- a/navi/src/test/java/com/trello/navi/NaviFragmentPluginTest.java
+++ b/navi/src/test/java/com/trello/navi/NaviFragmentPluginTest.java
@@ -1,0 +1,296 @@
+package com.trello.navi;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.content.res.Configuration;
+import android.os.Build;
+import android.os.Bundle;
+import android.os.PersistableBundle;
+import com.trello.navi.internal.NaviEmitter;
+import com.trello.navi.internal.NaviPlugin;
+import com.trello.navi.model.ActivityResult;
+import com.trello.navi.model.BundleBundle;
+import com.trello.navi.model.RequestPermissionsResult;
+import org.junit.Test;
+
+import static com.trello.navi.TestUtils.setSdkInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+public class NaviFragmentPluginTest {
+
+  private final NaviEmitter emitter = NaviEmitter.createFragmentEmitter();
+  private FragmentNaviPlugin plugin = spy(new FragmentNaviPlugin());
+
+  @Test public void testOnCreate() throws Exception {
+    emitter.addPlugin(plugin);
+    verify(plugin).getEvents();
+
+    Bundle bundle = mock(Bundle.class);
+    emitter.onCreate(bundle);
+    verify(plugin).onEvent(Event.CREATE, bundle);
+    verify(plugin).onCreate(bundle);
+
+    emitter.removePlugin(plugin);
+    emitter.onCreate(bundle);
+    verifyNoMoreInteractions(plugin);
+  }
+
+  @Test public void testOnStart() throws Exception {
+    emitter.addPlugin(plugin);
+    verify(plugin).getEvents();
+
+    emitter.onStart();
+    verify(plugin).onEvent(Event.START, null);
+    verify(plugin).onStart();
+
+    emitter.removePlugin(plugin);
+    emitter.onStart();
+    verifyNoMoreInteractions(plugin);
+  }
+
+  @Test public void testOnResume() throws Exception {
+    emitter.addPlugin(plugin);
+    verify(plugin).getEvents();
+
+    emitter.onResume();
+    verify(plugin).onEvent(Event.RESUME, null);
+    verify(plugin).onResume();
+
+    emitter.removePlugin(plugin);
+    emitter.onResume();
+    verifyNoMoreInteractions(plugin);
+  }
+
+  @Test public void testOnPause() throws Exception {
+    emitter.addPlugin(plugin);
+    verify(plugin).getEvents();
+
+    emitter.onPause();
+    verify(plugin).onEvent(Event.PAUSE, null);
+    verify(plugin).onPause();
+
+    emitter.removePlugin(plugin);
+    emitter.onPause();
+    verifyNoMoreInteractions(plugin);
+  }
+
+  @Test public void testStop() throws Exception {
+    emitter.addPlugin(plugin);
+    verify(plugin).getEvents();
+
+    emitter.onStop();
+    verify(plugin).onEvent(Event.STOP, null);
+    verify(plugin).onStop();
+
+    emitter.removePlugin(plugin);
+    emitter.onStop();
+    verifyNoMoreInteractions(plugin);
+  }
+
+  @Test public void testOnDestroy() throws Exception {
+    emitter.addPlugin(plugin);
+    verify(plugin).getEvents();
+
+    emitter.onDestroy();
+    verify(plugin).onEvent(Event.DESTROY, null);
+    verify(plugin).onDestroy();
+
+    emitter.removePlugin(plugin);
+    emitter.onDestroy();
+    verifyNoMoreInteractions(plugin);
+  }
+
+  @Test public void testOnSaveInstanceState() throws Exception {
+    emitter.addPlugin(plugin);
+    verify(plugin).getEvents();
+
+    Bundle bundle = mock(Bundle.class);
+    emitter.onSaveInstanceState(bundle);
+    verify(plugin).onEvent(Event.SAVE_INSTANCE_STATE, bundle);
+    verify(plugin).onSaveInstanceState(bundle);
+
+    emitter.removePlugin(plugin);
+    emitter.onSaveInstanceState(bundle);
+    verifyNoMoreInteractions(plugin);
+  }
+
+  @Test public void testOnConfigurationChanged() throws Exception {
+    emitter.addPlugin(plugin);
+    verify(plugin).getEvents();
+
+    Configuration configuration = mock(Configuration.class);
+    emitter.onConfigurationChanged(configuration);
+    verify(plugin).onEvent(Event.CONFIGURATION_CHANGED, configuration);
+    verify(plugin).onConfigurationChanged(configuration);
+
+    emitter.removePlugin(plugin);
+    emitter.onConfigurationChanged(configuration);
+    verifyNoMoreInteractions(plugin);
+  }
+
+  @Test public void testOnActivityResult() throws Exception {
+    emitter.addPlugin(plugin);
+    verify(plugin).getEvents();
+
+    Intent intent = mock(Intent.class);
+    final ActivityResult activityResult = new ActivityResult(0, 0, intent);
+    emitter.onActivityResult(0, 0, intent);
+    verify(plugin).onEvent(Event.ACTIVITY_RESULT, activityResult);
+    verify(plugin).onActivityResult(activityResult);
+
+    emitter.removePlugin(plugin);
+    emitter.onActivityResult(0, 0, intent);
+    verifyNoMoreInteractions(plugin);
+  }
+
+  @Test public void testOnRequestPermissionResult() throws Exception {
+    emitter.addPlugin(plugin);
+    verify(plugin).getEvents();
+
+    String[] permissions = new String[0];
+    int[] grantResults = new int[0];
+    final RequestPermissionsResult requestPermissionsResult =
+        new RequestPermissionsResult(0, permissions, grantResults);
+    emitter.onRequestPermissionsResult(0, permissions, grantResults);
+    verify(plugin).onEvent(Event.REQUEST_PERMISSIONS_RESULT, requestPermissionsResult);
+    verify(plugin).onRequestPermissionsResult(requestPermissionsResult);
+
+    emitter.removePlugin(plugin);
+    emitter.onRequestPermissionsResult(0, permissions, grantResults);
+    verifyNoMoreInteractions(plugin);
+  }
+
+  @Test public void testOnAttachWithContext_PostM() throws Exception {
+    setSdkInt(Build.VERSION_CODES.M);
+    emitter.addPlugin(plugin);
+    verify(plugin).getEvents();
+
+    Context context = mock(Context.class);
+    emitter.onAttach(context);
+    verify(plugin).onEvent(Event.ATTACH, context);
+    verify(plugin).onAttach(context);
+
+    emitter.removePlugin(plugin);
+    emitter.onAttach(context);
+    verifyNoMoreInteractions(plugin);
+  }
+  @Test public void testOnAttachWithContext_PreM() throws Exception {
+    setSdkInt(Build.VERSION_CODES.LOLLIPOP);
+    emitter.addPlugin(plugin);
+    verify(plugin).getEvents();
+
+    Context context = mock(Context.class);
+    emitter.onAttach(context);
+    // will not be called. Not supported on pre M
+    verify(plugin, times(0)).onEvent(Event.ATTACH, context);
+    verify(plugin, times(0)).onAttach(context);
+
+    emitter.removePlugin(plugin);
+    emitter.onAttach(context);
+    verifyNoMoreInteractions(plugin);
+  }
+
+  @Test public void testOnAttachWithActivity_PostM() throws Exception {
+    setSdkInt(Build.VERSION_CODES.M);
+    emitter.addPlugin(plugin);
+    verify(plugin).getEvents();
+
+    Activity activity = mock(Activity.class);
+    emitter.onAttach(activity);
+    // will not be called. Not supported on post M
+    verify(plugin, times(0)).onEvent(Event.ATTACH, activity);
+    verify(plugin, times(0)).onAttach(activity);
+
+    emitter.removePlugin(plugin);
+    emitter.onAttach(activity);
+    verifyNoMoreInteractions(plugin);
+  }
+
+  @Test public void testOnAttachWithActivity_PreM() throws Exception {
+    setSdkInt(Build.VERSION_CODES.LOLLIPOP);
+    emitter.addPlugin(plugin);
+    verify(plugin).getEvents();
+
+    Activity activity = mock(Activity.class);
+    emitter.onAttach(activity);
+    verify(plugin).onEvent(Event.ATTACH, activity);
+    verify(plugin).onAttach(activity);
+
+    emitter.removePlugin(plugin);
+    emitter.onAttach(activity);
+    verifyNoMoreInteractions(plugin);
+  }
+
+  @Test public void testOnCreateView() throws Exception {
+    emitter.addPlugin(plugin);
+    verify(plugin).getEvents();
+
+    Bundle bundle = mock(Bundle.class);
+    emitter.onCreateView(bundle);
+    verify(plugin).onEvent(Event.CREATE_VIEW, bundle);
+    verify(plugin).onCreateView(bundle);
+
+    emitter.removePlugin(plugin);
+    emitter.onCreateView(bundle);
+    verifyNoMoreInteractions(plugin);
+  }
+
+  @Test public void testOnActivityCreated() throws Exception {
+    emitter.addPlugin(plugin);
+    verify(plugin).getEvents();
+
+    Bundle bundle = mock(Bundle.class);
+    emitter.onActivityCreated(bundle);
+    verify(plugin).onEvent(Event.ACTIVITY_CREATED, bundle);
+    verify(plugin).onActivityCreated(bundle);
+
+    emitter.removePlugin(plugin);
+    emitter.onActivityCreated(bundle);
+    verifyNoMoreInteractions(plugin);
+  }
+
+  @Test public void testOnViewStateRestored() throws Exception {
+    emitter.addPlugin(plugin);
+    verify(plugin).getEvents();
+
+    Bundle bundle = mock(Bundle.class);
+    emitter.onViewStateRestored(bundle);
+    verify(plugin).onEvent(Event.VIEW_STATE_RESTORED, bundle);
+    verify(plugin).onViewStateRestored(bundle);
+
+    emitter.removePlugin(plugin);
+    emitter.onViewStateRestored(bundle);
+    verifyNoMoreInteractions(plugin);
+  }
+
+  @Test public void testOnDestroyView() throws Exception {
+    emitter.addPlugin(plugin);
+    verify(plugin).getEvents();
+
+    emitter.onDestroyView();
+    verify(plugin).onEvent(Event.DESTROY_VIEW, null);
+    verify(plugin).onDestroyView();
+
+    emitter.removePlugin(plugin);
+    emitter.onDestroyView();
+    verifyNoMoreInteractions(plugin);
+  }
+
+  @Test public void testOnDetach() throws Exception {
+    emitter.addPlugin(plugin);
+    verify(plugin).getEvents();
+
+    emitter.onDetach();
+    verify(plugin).onEvent(Event.DETACH, null);
+    verify(plugin).onDetach();
+
+    emitter.removePlugin(plugin);
+    emitter.onDetach();
+    verifyNoMoreInteractions(plugin);
+  }
+}

--- a/navi/src/test/java/com/trello/navi/NaviPluginTest.java
+++ b/navi/src/test/java/com/trello/navi/NaviPluginTest.java
@@ -1,0 +1,38 @@
+package com.trello.navi;
+
+import com.trello.navi.internal.NaviEmitter;
+import com.trello.navi.internal.NaviPlugin;
+import java.util.Arrays;
+import org.junit.Test;
+
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+public class NaviPluginTest {
+
+  @Test public void addRemovePlugin() {
+    NaviPlugin plugin = spy(new NaviPlugin(Event.START) {
+      @Override public <T> void onEvent(Event<T> event, T data) {
+
+      }
+    });
+    NaviEmitter emitter = new NaviEmitter(Arrays.<Event<?>>asList(Event.START));
+
+    emitter.addPlugin(plugin);
+    verify(plugin).getEvents();
+
+    emitter.onStart();
+    verify(plugin).onEvent(Event.START, null);
+
+    emitter.removePlugin(plugin);
+    emitter.onStart();
+    verifyNoMoreInteractions(plugin);
+  }
+
+  @Test(expected = IllegalArgumentException.class) public void addWrongPlugin() throws Exception {
+    NaviEmitter emitter = NaviEmitter.createFragmentEmitter();
+    ActivityNaviPlugin plugin = new ActivityNaviPlugin();
+    emitter.addPlugin(plugin);
+  }
+}

--- a/navi/src/test/java/com/trello/navi/PluginTest.java
+++ b/navi/src/test/java/com/trello/navi/PluginTest.java
@@ -1,0 +1,334 @@
+package com.trello.navi;
+
+import android.content.Intent;
+import android.content.res.Configuration;
+import android.os.Bundle;
+import android.os.PersistableBundle;
+import com.trello.navi.internal.NaviEmitter;
+import com.trello.navi.model.ActivityResult;
+import com.trello.navi.model.BundleBundle;
+import com.trello.navi.model.RequestPermissionsResult;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+public class PluginTest {
+
+  private final NaviEmitter emitter = NaviEmitter.createActivityEmitter();
+
+  @Test public void addRemovePlugin() {
+    ActivityNaviPlugin plugin = spy(new ActivityNaviPlugin());
+    emitter.addPlugin(plugin);
+    verify(plugin).getEvents();
+
+    emitter.onStart();
+    verify(plugin).onEvent(Event.START, null);
+    verify(plugin).onStart();
+
+    emitter.removePlugin(plugin);
+    emitter.onStart();
+    verifyNoMoreInteractions(plugin);
+  }
+
+  @Test(expected = IllegalArgumentException.class) public void addWrongPlugin()
+      throws Exception {
+    NaviEmitter emitter = NaviEmitter.createFragmentEmitter();
+    ActivityNaviPlugin plugin = new ActivityNaviPlugin();
+    emitter.addPlugin(plugin);
+  }
+
+  @Test public void testOnCreate() throws Exception {
+    ActivityNaviPlugin plugin = spy(new ActivityNaviPlugin());
+    emitter.addPlugin(plugin);
+    verify(plugin).getEvents();
+
+    Bundle bundle = mock(Bundle.class);
+    emitter.onCreate(bundle);
+    verify(plugin).onEvent(Event.CREATE, bundle);
+    verify(plugin).onCreate(bundle);
+
+    emitter.removePlugin(plugin);
+    emitter.onCreate(bundle);
+    verifyNoMoreInteractions(plugin);
+  }
+
+  @Test public void testOnCreatePersistable() throws Exception {
+    ActivityNaviPlugin plugin = spy(new ActivityNaviPlugin());
+    emitter.addPlugin(plugin);
+    verify(plugin).getEvents();
+
+    Bundle bundle = mock(Bundle.class);
+    PersistableBundle persistentState = mock(PersistableBundle.class);
+    final BundleBundle bundleBundle = new BundleBundle(bundle, persistentState);
+    emitter.onCreate(bundle, persistentState);
+    verify(plugin).onEvent(Event.CREATE, bundle);
+    verify(plugin).onEvent(Event.CREATE_PERSISTABLE, bundleBundle);
+    verify(plugin).onCreate(bundle);
+    verify(plugin).onCreate(bundleBundle);
+
+    emitter.removePlugin(plugin);
+    emitter.onCreate(bundle, persistentState);
+    verifyNoMoreInteractions(plugin);
+  }
+
+  @Test public void testOnStart() throws Exception {
+    ActivityNaviPlugin plugin = spy(new ActivityNaviPlugin());
+    emitter.addPlugin(plugin);
+    verify(plugin).getEvents();
+
+    emitter.onStart();
+    verify(plugin).onEvent(Event.START, null);
+    verify(plugin).onStart();
+
+    emitter.removePlugin(plugin);
+    emitter.onStart();
+    verifyNoMoreInteractions(plugin);
+  }
+
+  @Test public void testOnResume() throws Exception {
+    ActivityNaviPlugin plugin = spy(new ActivityNaviPlugin());
+    emitter.addPlugin(plugin);
+    verify(plugin).getEvents();
+
+    emitter.onResume();
+    verify(plugin).onEvent(Event.RESUME, null);
+    verify(plugin).onResume();
+
+    emitter.removePlugin(plugin);
+    emitter.onResume();
+    verifyNoMoreInteractions(plugin);
+  }
+
+  @Test public void testOnPause() throws Exception {
+    ActivityNaviPlugin plugin = spy(new ActivityNaviPlugin());
+    emitter.addPlugin(plugin);
+    verify(plugin).getEvents();
+
+    emitter.onPause();
+    verify(plugin).onEvent(Event.PAUSE, null);
+    verify(plugin).onPause();
+
+    emitter.removePlugin(plugin);
+    emitter.onPause();
+    verifyNoMoreInteractions(plugin);
+  }
+
+  @Test public void testStop() throws Exception {
+    ActivityNaviPlugin plugin = spy(new ActivityNaviPlugin());
+    emitter.addPlugin(plugin);
+    verify(plugin).getEvents();
+
+    emitter.onStop();
+    verify(plugin).onEvent(Event.STOP, null);
+    verify(plugin).onStop();
+
+    emitter.removePlugin(plugin);
+    emitter.onStop();
+    verifyNoMoreInteractions(plugin);
+  }
+
+  @Test public void testOnDestroy() throws Exception {
+    ActivityNaviPlugin plugin = spy(new ActivityNaviPlugin());
+    emitter.addPlugin(plugin);
+    verify(plugin).getEvents();
+
+    emitter.onDestroy();
+    verify(plugin).onEvent(Event.DESTROY, null);
+    verify(plugin).onDestroy();
+
+    emitter.removePlugin(plugin);
+    emitter.onDestroy();
+    verifyNoMoreInteractions(plugin);
+  }
+
+  @Test public void testOnSaveInstanceState() throws Exception {
+    ActivityNaviPlugin plugin = spy(new ActivityNaviPlugin());
+    emitter.addPlugin(plugin);
+    verify(plugin).getEvents();
+
+    Bundle bundle = mock(Bundle.class);
+    emitter.onSaveInstanceState(bundle);
+    verify(plugin).onEvent(Event.SAVE_INSTANCE_STATE, bundle);
+    verify(plugin).onSaveInstanceState(bundle);
+
+    emitter.removePlugin(plugin);
+    emitter.onSaveInstanceState(bundle);
+    verifyNoMoreInteractions(plugin);
+  }
+
+  @Test public void testOnSaveInstanceStatePersistable() throws Exception {
+    ActivityNaviPlugin plugin = spy(new ActivityNaviPlugin());
+    emitter.addPlugin(plugin);
+    verify(plugin).getEvents();
+
+    Bundle bundle = mock(Bundle.class);
+    PersistableBundle persistentState = mock(PersistableBundle.class);
+    final BundleBundle bundleBundle = new BundleBundle(bundle, persistentState);
+    emitter.onSaveInstanceState(bundle, persistentState);
+    verify(plugin).onEvent(Event.SAVE_INSTANCE_STATE, bundle);
+    verify(plugin).onEvent(Event.SAVE_INSTANCE_STATE_PERSISTABLE, bundleBundle);
+    verify(plugin).onSaveInstanceState(bundle);
+    verify(plugin).onSaveInstanceState(bundleBundle);
+
+    emitter.removePlugin(plugin);
+    emitter.onSaveInstanceState(bundle, persistentState);
+    verifyNoMoreInteractions(plugin);
+  }
+
+  @Test public void testOnConfigurationChanged() throws Exception {
+    ActivityNaviPlugin plugin = spy(new ActivityNaviPlugin());
+    emitter.addPlugin(plugin);
+    verify(plugin).getEvents();
+
+    Configuration configuration = mock(Configuration.class);
+    emitter.onConfigurationChanged(configuration);
+    verify(plugin).onEvent(Event.CONFIGURATION_CHANGED, configuration);
+    verify(plugin).onConfigurationChanged(configuration);
+
+    emitter.removePlugin(plugin);
+    emitter.onConfigurationChanged(configuration);
+    verifyNoMoreInteractions(plugin);
+  }
+
+  @Test public void testOnActivityResult() throws Exception {
+    ActivityNaviPlugin plugin = spy(new ActivityNaviPlugin());
+    emitter.addPlugin(plugin);
+    verify(plugin).getEvents();
+
+    Intent intent = mock(Intent.class);
+    final ActivityResult activityResult = new ActivityResult(0, 0, intent);
+    emitter.onActivityResult(0, 0, intent);
+    verify(plugin).onEvent(Event.ACTIVITY_RESULT, activityResult);
+    verify(plugin).onActivityResult(activityResult);
+
+    emitter.removePlugin(plugin);
+    emitter.onActivityResult(0, 0, intent);
+    verifyNoMoreInteractions(plugin);
+  }
+
+  @Test public void testOnRequestPermissionResult() throws Exception {
+    ActivityNaviPlugin plugin = spy(new ActivityNaviPlugin());
+    emitter.addPlugin(plugin);
+    verify(plugin).getEvents();
+
+    String[] permissions = new String[0];
+    int[] grantResults = new int[0];
+    final RequestPermissionsResult requestPermissionsResult =
+        new RequestPermissionsResult(0, permissions, grantResults);
+    emitter.onRequestPermissionsResult(0, permissions, grantResults);
+    verify(plugin).onEvent(Event.REQUEST_PERMISSIONS_RESULT, requestPermissionsResult);
+    verify(plugin).onRequestPermissionsResult(requestPermissionsResult);
+
+    emitter.removePlugin(plugin);
+    emitter.onRequestPermissionsResult(0, permissions, grantResults);
+    verifyNoMoreInteractions(plugin);
+  }
+
+  @Test public void testOnRestart() throws Exception {
+    ActivityNaviPlugin plugin = spy(new ActivityNaviPlugin());
+    emitter.addPlugin(plugin);
+    verify(plugin).getEvents();
+
+    emitter.onRestart();
+    verify(plugin).onEvent(Event.RESTART, null);
+    verify(plugin).onRestart();
+
+    emitter.removePlugin(plugin);
+    emitter.onRestart();
+    verifyNoMoreInteractions(plugin);
+  }
+
+  @Test public void testOnRestoreInstanceState() throws Exception {
+    ActivityNaviPlugin plugin = spy(new ActivityNaviPlugin());
+    emitter.addPlugin(plugin);
+    verify(plugin).getEvents();
+
+    Bundle bundle = mock(Bundle.class);
+    emitter.onRestoreInstanceState(bundle);
+    verify(plugin).onEvent(Event.RESTORE_INSTANCE_STATE, bundle);
+    verify(plugin).onRestoreInstanceState(bundle);
+
+    emitter.removePlugin(plugin);
+    emitter.onRestoreInstanceState(bundle);
+    verifyNoMoreInteractions(plugin);
+  }
+
+  @Test public void testOnRestoreInstanceStatePersistable() throws Exception {
+    ActivityNaviPlugin plugin = spy(new ActivityNaviPlugin());
+    emitter.addPlugin(plugin);
+    verify(plugin).getEvents();
+
+    Bundle bundle = mock(Bundle.class);
+    PersistableBundle persistentState = mock(PersistableBundle.class);
+    final BundleBundle bundleBundle = new BundleBundle(bundle, persistentState);
+    emitter.onRestoreInstanceState(bundle, persistentState);
+    verify(plugin).onEvent(Event.RESTORE_INSTANCE_STATE, bundle);
+    verify(plugin).onEvent(Event.RESTORE_INSTANCE_STATE_PERSISTABLE, bundleBundle);
+    verify(plugin).onRestoreInstanceState(bundle);
+    verify(plugin).onRestoreInstanceState(bundleBundle);
+
+    emitter.removePlugin(plugin);
+    emitter.onRestoreInstanceState(bundle, persistentState);
+    verifyNoMoreInteractions(plugin);
+  }
+
+  @Test public void testOnNewIntent() throws Exception {
+    ActivityNaviPlugin plugin = spy(new ActivityNaviPlugin());
+    emitter.addPlugin(plugin);
+    verify(plugin).getEvents();
+
+    Intent intent = mock(Intent.class);
+    emitter.onNewIntent(intent);
+    verify(plugin).onEvent(Event.NEW_INTENT, intent);
+    verify(plugin).onNewIntent(intent);
+
+    emitter.removePlugin(plugin);
+    emitter.onNewIntent(intent);
+    verifyNoMoreInteractions(plugin);
+  }
+
+  @Test public void testOnBackPressed() throws Exception {
+    ActivityNaviPlugin plugin = spy(new ActivityNaviPlugin());
+    emitter.addPlugin(plugin);
+    verify(plugin).getEvents();
+
+    emitter.onBackPressed();
+    verify(plugin).onEvent(Event.BACK_PRESSED, null);
+    verify(plugin).onBackPressed();
+
+    emitter.removePlugin(plugin);
+    emitter.onBackPressed();
+    verifyNoMoreInteractions(plugin);
+  }
+
+  @Test public void testOnAttachedToWindow() throws Exception {
+    ActivityNaviPlugin plugin = spy(new ActivityNaviPlugin());
+    emitter.addPlugin(plugin);
+    verify(plugin).getEvents();
+
+    emitter.onAttachedToWindow();
+    verify(plugin).onEvent(Event.ATTACHED_TO_WINDOW, null);
+    verify(plugin).onAttachedToWindow();
+
+    emitter.removePlugin(plugin);
+    emitter.onAttachedToWindow();
+    verifyNoMoreInteractions(plugin);
+  }
+
+  @Test public void testOnDetachedToWindow() throws Exception {
+    ActivityNaviPlugin plugin = spy(new ActivityNaviPlugin());
+    emitter.addPlugin(plugin);
+    verify(plugin).getEvents();
+
+    emitter.onDetachedFromWindow();
+    verify(plugin).onEvent(Event.DETACHED_FROM_WINDOW, null);
+    verify(plugin).onDetachedFromWindow();
+
+    emitter.removePlugin(plugin);
+    emitter.onDetachedFromWindow();
+    verifyNoMoreInteractions(plugin);
+  }
+}

--- a/navi/src/test/java/com/trello/navi/PluginTest.java
+++ b/navi/src/test/java/com/trello/navi/PluginTest.java
@@ -5,6 +5,7 @@ import android.content.res.Configuration;
 import android.os.Bundle;
 import android.os.PersistableBundle;
 import com.trello.navi.internal.NaviEmitter;
+import com.trello.navi.internal.NaviPlugin;
 import com.trello.navi.model.ActivityResult;
 import com.trello.navi.model.BundleBundle;
 import com.trello.navi.model.RequestPermissionsResult;
@@ -20,13 +21,16 @@ public class PluginTest {
   private final NaviEmitter emitter = NaviEmitter.createActivityEmitter();
 
   @Test public void addRemovePlugin() {
-    ActivityNaviPlugin plugin = spy(new ActivityNaviPlugin());
+    NaviPlugin plugin = spy(new NaviPlugin(Event.START) {
+      @Override public <T> void onEvent(Event<T> event, T data) {
+
+      }
+    });
     emitter.addPlugin(plugin);
     verify(plugin).getEvents();
 
     emitter.onStart();
     verify(plugin).onEvent(Event.START, null);
-    verify(plugin).onStart();
 
     emitter.removePlugin(plugin);
     emitter.onStart();


### PR DESCRIPTION
While adding support for navi for a library I struggled creating a simple way to bind to all events I need. I ended up creating my library object and binding it multiple times with `addListener(myLib);` to the `NaviActivity`. In the `README` for my lib I have to add "add those 10 lines to make my lib work". This adds too much complexity and show implementation details to the implementer which is not needed.
Even worse: When updating my lib, it may happen that I have to add a new listener. This would require the user of my lib to update the version **and** *update the binding listeners*!

With this plugin feature it's more like "simply add `addPlugin(new MyPlugin());` in you `NaviActivity` and you are fine".

`ActivityNaviPlugin` is the default implementation. A plugin for `Fragment` will follow

- [x] add `FragmentNaviPlugin`

The `ALL` listener is not a solution to this problem. It only listens *when* events happen and don't give the data of events such as the `Bundle` in `#onSaveInstanceState(Bundle)`;