### PR TITLE
Add Tests for Exception when adding/removing a listener for an unsupported event

### DIFF
--- a/navi/src/test/java/com/trello/navi/EventHandlingTest.java
+++ b/navi/src/test/java/com/trello/navi/EventHandlingTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 public class EventHandlingTest {
   @Test public void handlesEventsNone() {
@@ -23,5 +24,17 @@ public class EventHandlingTest {
     assertTrue(component.handlesEvents(Event.CREATE, Event.START, Event.RESUME));
     assertFalse(component.handlesEvents(Event.ATTACH, Event.CREATE_VIEW));
     assertFalse(component.handlesEvents(Event.CREATE, Event.CREATE_VIEW));
+  }
+
+  @Test(expected = IllegalArgumentException.class) public void throwOnRemoveUnsupportedListener()
+      throws Exception {
+    final NaviEmitter emitter = NaviEmitter.createActivityEmitter();
+    emitter.removeListener(Event.DETACH, mock(Listener.class));
+  }
+
+  @Test(expected = IllegalArgumentException.class) public void throwOnAddUnsupportedListener()
+      throws Exception {
+    final NaviEmitter emitter = NaviEmitter.createActivityEmitter();
+    emitter.addListener(Event.DETACH, mock(Listener.class));
   }
 }


### PR DESCRIPTION
those tests where missing to reach a fully tested `NaviEmitter`