### PR TITLE
Switch to using @Rule ExpectedException

### DIFF
--- a/navi/src/test/java/com/trello/navi/EventHandlingTest.java
+++ b/navi/src/test/java/com/trello/navi/EventHandlingTest.java
@@ -1,13 +1,18 @@
 package com.trello.navi;
 
 import com.trello.navi.internal.NaviEmitter;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 public class EventHandlingTest {
+
+  @Rule public final ExpectedException exception = ExpectedException.none();
+
   @Test public void handlesEventsNone() {
     NaviComponent component = NaviEmitter.createActivityEmitter();
     assertTrue(component.handlesEvents());
@@ -26,15 +31,15 @@ public class EventHandlingTest {
     assertFalse(component.handlesEvents(Event.CREATE, Event.CREATE_VIEW));
   }
 
-  @Test(expected = IllegalArgumentException.class) public void throwOnRemoveUnsupportedListener()
-      throws Exception {
+  @Test public void throwOnRemoveUnsupportedListener() {
     final NaviEmitter emitter = NaviEmitter.createActivityEmitter();
+    exception.expect(IllegalArgumentException.class);
     emitter.removeListener(Event.DETACH, mock(Listener.class));
   }
 
-  @Test(expected = IllegalArgumentException.class) public void throwOnAddUnsupportedListener()
-      throws Exception {
+  @Test public void throwOnAddUnsupportedListener() {
     final NaviEmitter emitter = NaviEmitter.createActivityEmitter();
+    exception.expect(IllegalArgumentException.class);
     emitter.addListener(Event.DETACH, mock(Listener.class));
   }
 }

--- a/navi/src/test/java/com/trello/navi/NaviActivityTest.java
+++ b/navi/src/test/java/com/trello/navi/NaviActivityTest.java
@@ -9,13 +9,17 @@ import com.trello.navi.internal.NaviEmitter;
 import com.trello.navi.model.ActivityResult;
 import com.trello.navi.model.BundleBundle;
 import com.trello.navi.model.RequestPermissionsResult;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public final class NaviActivityTest {
+
+  @Rule public final ExpectedException exception = ExpectedException.none();
 
   private final NaviEmitter emitter = NaviEmitter.createActivityEmitter();
 
@@ -281,27 +285,33 @@ public final class NaviActivityTest {
 
   // The below should not work with activities
 
-  @Test(expected = IllegalArgumentException.class) public void attachListener() {
+  @Test public void attachListener() {
+    exception.expect(IllegalArgumentException.class);
     emitter.addListener(Event.ATTACH, mock(Listener.class));
   }
 
-  @Test(expected = IllegalArgumentException.class) public void createViewListener() {
+  @Test public void createViewListener() {
+    exception.expect(IllegalArgumentException.class);
     emitter.addListener(Event.CREATE_VIEW, mock(Listener.class));
   }
 
-  @Test(expected = IllegalArgumentException.class) public void activityCreatedListener() {
+  @Test public void activityCreatedListener() {
+    exception.expect(IllegalArgumentException.class);
     emitter.addListener(Event.ACTIVITY_CREATED, mock(Listener.class));
   }
 
-  @Test(expected = IllegalArgumentException.class) public void viewStateRestoredListener() {
+  @Test public void viewStateRestoredListener() {
+    exception.expect(IllegalArgumentException.class);
     emitter.addListener(Event.VIEW_STATE_RESTORED, mock(Listener.class));
   }
 
-  @Test(expected = IllegalArgumentException.class) public void destroyViewListener() {
+  @Test public void destroyViewListener() {
+    exception.expect(IllegalArgumentException.class);
     emitter.addListener(Event.DESTROY_VIEW, mock(Listener.class));
   }
 
-  @Test(expected = IllegalArgumentException.class) public void detachListener() {
+  @Test public void detachListener() {
+    exception.expect(IllegalArgumentException.class);
     emitter.addListener(Event.DETACH, mock(Listener.class));
   }
 }

--- a/navi/src/test/java/com/trello/navi/NaviFragmentTest.java
+++ b/navi/src/test/java/com/trello/navi/NaviFragmentTest.java
@@ -8,7 +8,9 @@ import android.os.Bundle;
 import com.trello.navi.internal.NaviEmitter;
 import com.trello.navi.model.ActivityResult;
 import com.trello.navi.model.RequestPermissionsResult;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static com.trello.navi.TestUtils.setSdkInt;
 import static org.mockito.Mockito.mock;
@@ -16,6 +18,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public final class NaviFragmentTest {
+
+  @Rule public final ExpectedException exception = ExpectedException.none();
 
   private final NaviEmitter emitter = NaviEmitter.createFragmentEmitter();
 
@@ -245,41 +249,50 @@ public final class NaviFragmentTest {
 
   // The below should not work with fragments
 
-  @Test(expected = IllegalArgumentException.class) public void createPersistableListener() {
+  @Test public void createPersistableListener() {
+    exception.expect(IllegalArgumentException.class);
     emitter.addListener(Event.CREATE_PERSISTABLE, mock(Listener.class));
   }
 
-  @Test(expected = IllegalArgumentException.class) public void restartListener() {
+  @Test public void restartListener() {
+    exception.expect(IllegalArgumentException.class);
     emitter.addListener(Event.RESTART, mock(Listener.class));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void saveInstanceStatePersistableListener() {
+    exception.expect(IllegalArgumentException.class);
     emitter.addListener(Event.SAVE_INSTANCE_STATE_PERSISTABLE, mock(Listener.class));
   }
 
-  @Test(expected = IllegalArgumentException.class) public void restoreInstanceStateListener() {
+  @Test public void restoreInstanceStateListener() {
+    exception.expect(IllegalArgumentException.class);
     emitter.addListener(Event.RESTORE_INSTANCE_STATE, mock(Listener.class));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void restoreInstanceStatePersistableListener() {
+    exception.expect(IllegalArgumentException.class);
     emitter.addListener(Event.RESTORE_INSTANCE_STATE_PERSISTABLE, mock(Listener.class));
   }
 
-  @Test(expected = IllegalArgumentException.class) public void newIntentListener() {
+  @Test public void newIntentListener() {
+    exception.expect(IllegalArgumentException.class);
     emitter.addListener(Event.NEW_INTENT, mock(Listener.class));
   }
 
-  @Test(expected = IllegalArgumentException.class) public void backPressedListener() {
+  @Test public void backPressedListener() {
+    exception.expect(IllegalArgumentException.class);
     emitter.addListener(Event.BACK_PRESSED, mock(Listener.class));
   }
 
-  @Test(expected = IllegalArgumentException.class) public void attachedToWindowListener() {
+  @Test public void attachedToWindowListener() {
+    exception.expect(IllegalArgumentException.class);
     emitter.addListener(Event.ATTACHED_TO_WINDOW, mock(Listener.class));
   }
 
-  @Test(expected = IllegalArgumentException.class) public void detachedFromWindowListener() {
+  @Test public void detachedFromWindowListener() {
+    exception.expect(IllegalArgumentException.class);
     emitter.addListener(Event.DETACHED_FROM_WINDOW, mock(Listener.class));
   }
 }


### PR DESCRIPTION
This allows us to pinpoint exactly when we expect the exception, rather than
just catching an exception that happens anywhere in the test.

Fixes #31 