### PR TITLE
Use `final` modifier for interface implementations

### DIFF
--- a/navi/src/main/java/com/trello/navi/component/NaviActivity.java
+++ b/navi/src/main/java/com/trello/navi/component/NaviActivity.java
@@ -16,15 +16,15 @@ public class NaviActivity extends Activity implements NaviComponent {
 
   private final NaviEmitter base = NaviEmitter.createActivityEmitter();
 
-  @Override public boolean handlesEvents(Event... events) {
+  @Override public final boolean handlesEvents(Event... events) {
     return base.handlesEvents(events);
   }
 
-  @Override public <T> void addListener(Event<T> event, Listener<T> listener) {
+  @Override public final <T> void addListener(Event<T> event, Listener<T> listener) {
     base.addListener(event, listener);
   }
 
-  @Override public <T> void removeListener(Listener<T> listener) {
+  @Override public final <T> void removeListener(Listener<T> listener) {
     base.removeListener(listener);
   }
 

--- a/navi/src/main/java/com/trello/navi/component/NaviDialogFragment.java
+++ b/navi/src/main/java/com/trello/navi/component/NaviDialogFragment.java
@@ -21,15 +21,15 @@ public class NaviDialogFragment extends DialogFragment implements NaviComponent 
 
   private final NaviEmitter base = NaviEmitter.createFragmentEmitter();
 
-  @Override public boolean handlesEvents(Event... events) {
+  @Override public final boolean handlesEvents(Event... events) {
     return base.handlesEvents(events);
   }
 
-  @Override public <T> void addListener(Event<T> event, Listener<T> listener) {
+  @Override public final <T> void addListener(Event<T> event, Listener<T> listener) {
     base.addListener(event, listener);
   }
 
-  @Override public <T> void removeListener(Listener<T> listener) {
+  @Override public final <T> void removeListener(Listener<T> listener) {
     base.removeListener(listener);
   }
 

--- a/navi/src/main/java/com/trello/navi/component/NaviFragment.java
+++ b/navi/src/main/java/com/trello/navi/component/NaviFragment.java
@@ -21,15 +21,15 @@ public class NaviFragment extends Fragment implements NaviComponent {
 
   private final NaviEmitter base = NaviEmitter.createFragmentEmitter();
 
-  @Override public boolean handlesEvents(Event... events) {
+  @Override public final boolean handlesEvents(Event... events) {
     return base.handlesEvents(events);
   }
 
-  @Override public <T> void addListener(Event<T> event, Listener<T> listener) {
+  @Override public final <T> void addListener(Event<T> event, Listener<T> listener) {
     base.addListener(event, listener);
   }
 
-  @Override public <T> void removeListener(Listener<T> listener) {
+  @Override public final <T> void removeListener(Listener<T> listener) {
     base.removeListener(listener);
   }
 

--- a/navi/src/main/java/com/trello/navi/component/support/NaviAppCompatActivity.java
+++ b/navi/src/main/java/com/trello/navi/component/support/NaviAppCompatActivity.java
@@ -16,15 +16,15 @@ public class NaviAppCompatActivity extends AppCompatActivity implements NaviComp
 
   private final NaviEmitter base = NaviEmitter.createActivityEmitter();
 
-  @Override public boolean handlesEvents(Event... events) {
+  @Override public final boolean handlesEvents(Event... events) {
     return base.handlesEvents(events);
   }
 
-  @Override public <T> void addListener(Event<T> event, Listener<T> listener) {
+  @Override public final <T> void addListener(Event<T> event, Listener<T> listener) {
     base.addListener(event, listener);
   }
 
-  @Override public <T> void removeListener(Listener<T> listener) {
+  @Override public final <T> void removeListener(Listener<T> listener) {
     base.removeListener(listener);
   }
 

--- a/navi/src/main/java/com/trello/navi/component/support/NaviAppCompatDialogFragment.java
+++ b/navi/src/main/java/com/trello/navi/component/support/NaviAppCompatDialogFragment.java
@@ -21,15 +21,15 @@ public class NaviAppCompatDialogFragment extends DialogFragment implements NaviC
 
   private final NaviEmitter base = NaviEmitter.createFragmentEmitter();
 
-  @Override public boolean handlesEvents(Event... events) {
+  @Override public final boolean handlesEvents(Event... events) {
     return base.handlesEvents(events);
   }
 
-  @Override public <T> void addListener(Event<T> event, Listener<T> listener) {
+  @Override public final <T> void addListener(Event<T> event, Listener<T> listener) {
     base.addListener(event, listener);
   }
 
-  @Override public <T> void removeListener(Listener<T> listener) {
+  @Override public final <T> void removeListener(Listener<T> listener) {
     base.removeListener(listener);
   }
 

--- a/navi/src/main/java/com/trello/navi/component/support/NaviDialogFragment.java
+++ b/navi/src/main/java/com/trello/navi/component/support/NaviDialogFragment.java
@@ -21,15 +21,15 @@ public class NaviDialogFragment extends DialogFragment implements NaviComponent 
 
   private final NaviEmitter base = NaviEmitter.createFragmentEmitter();
 
-  @Override public boolean handlesEvents(Event... events) {
+  @Override public final boolean handlesEvents(Event... events) {
     return base.handlesEvents(events);
   }
 
-  @Override public <T> void addListener(Event<T> event, Listener<T> listener) {
+  @Override public final <T> void addListener(Event<T> event, Listener<T> listener) {
     base.addListener(event, listener);
   }
 
-  @Override public <T> void removeListener(Listener<T> listener) {
+  @Override public final <T> void removeListener(Listener<T> listener) {
     base.removeListener(listener);
   }
 

--- a/navi/src/main/java/com/trello/navi/component/support/NaviFragment.java
+++ b/navi/src/main/java/com/trello/navi/component/support/NaviFragment.java
@@ -21,15 +21,15 @@ public class NaviFragment extends Fragment implements NaviComponent {
 
   private final NaviEmitter base = NaviEmitter.createFragmentEmitter();
 
-  @Override public boolean handlesEvents(Event... events) {
+  @Override public final boolean handlesEvents(Event... events) {
     return base.handlesEvents(events);
   }
 
-  @Override public <T> void addListener(Event<T> event, Listener<T> listener) {
+  @Override public final <T> void addListener(Event<T> event, Listener<T> listener) {
     base.addListener(event, listener);
   }
 
-  @Override public <T> void removeListener(Listener<T> listener) {
+  @Override public final <T> void removeListener(Listener<T> listener) {
     base.removeListener(listener);
   }
 

--- a/navi/src/main/java/com/trello/navi/internal/NaviEmitter.java
+++ b/navi/src/main/java/com/trello/navi/internal/NaviEmitter.java
@@ -54,7 +54,7 @@ public final class NaviEmitter implements NaviComponent {
     return new NaviEmitter(HandledEvents.FRAGMENT_EVENTS);
   }
 
-  @Override public boolean handlesEvents(Event... events) {
+  @Override public final boolean handlesEvents(Event... events) {
     for (int a = 0; a < events.length; a++) {
       Event event = events[a];
       if (event != Event.ALL && !handledEvents.contains(event)) {
@@ -65,7 +65,7 @@ public final class NaviEmitter implements NaviComponent {
     return true;
   }
 
-  @Override public <T> void addListener(Event<T> event, Listener<T> listener) {
+  @Override public final <T> void addListener(Event<T> event, Listener<T> listener) {
     if (!handlesEvents(event)) {
       throw new IllegalArgumentException("This component cannot handle event " + event);
     }
@@ -91,7 +91,7 @@ public final class NaviEmitter implements NaviComponent {
     listeners.add(listener);
   }
 
-  @Override public <T> void removeListener(Listener<T> listener) {
+  @Override public final <T> void removeListener(Listener<T> listener) {
     final Event event = eventMap.remove(listener);
     if (event != null && listenerMap.containsKey(event)) {
       listenerMap.get(event).remove(listener);


### PR DESCRIPTION
We don't want people accidentally messing around with the
nuts and bolts of adding/removing listeners.