### PR TITLE
Use AutoValue for data classes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ buildscript {
   dependencies {
     classpath 'com.android.tools.build:gradle:2.2.2'
     classpath 'com.github.ben-manes:gradle-versions-plugin:0.13.0'
+    classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
   }
 }
 
@@ -31,4 +32,7 @@ ext {
 
   junit = 'junit:junit:4.12'
   mockito = 'org.mockito:mockito-core:2.2.9'
+
+  autoValue = 'com.google.auto.value:auto-value:1.3'
+  autoValueAnnotations = 'com.jakewharton.auto.value:auto-value-annotations:1.3'
 }

--- a/navi/build.gradle
+++ b/navi/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.library'
+apply plugin: 'com.neenbedankt.android-apt'
 
 android {
   compileSdkVersion rootProject.ext.compileSdkVersion
@@ -20,6 +21,9 @@ repositories {
 
 dependencies {
   compile rootProject.ext.supportAnnotations
+
+  apt rootProject.ext.autoValue
+  provided rootProject.ext.autoValueAnnotations
 
   // Optional dependencies, depending on if your project uses them
   provided rootProject.ext.rxJava

--- a/navi/src/main/java/com/trello/navi2/internal/NaviEmitter.java
+++ b/navi/src/main/java/com/trello/navi2/internal/NaviEmitter.java
@@ -137,7 +137,7 @@ public final class NaviEmitter implements NaviComponent {
   }
 
   public void onActivityResult(int requestCode, int resultCode, Intent data) {
-    emitEvent(Event.ACTIVITY_RESULT, new ActivityResult(requestCode, resultCode, data));
+    emitEvent(Event.ACTIVITY_RESULT, ActivityResult.create(requestCode, resultCode, data));
   }
 
   public void onAttach(Activity activity) {
@@ -169,7 +169,7 @@ public final class NaviEmitter implements NaviComponent {
   }
 
   public void onCreate(Bundle savedInstanceState, PersistableBundle persistentState) {
-    emitEvent(Event.CREATE_PERSISTABLE, new BundleBundle(savedInstanceState, persistentState));
+    emitEvent(Event.CREATE_PERSISTABLE, BundleBundle.create(savedInstanceState, persistentState));
   }
 
   public void onCreateView(Bundle savedInstanceState) {
@@ -177,7 +177,7 @@ public final class NaviEmitter implements NaviComponent {
   }
 
   public void onViewCreated(View view, Bundle bundle) {
-    emitEvent(Event.VIEW_CREATED, new ViewCreated(view, bundle));
+    emitEvent(Event.VIEW_CREATED, ViewCreated.create(view, bundle));
   }
 
   public void onDestroy() {
@@ -209,13 +209,13 @@ public final class NaviEmitter implements NaviComponent {
   }
 
   public void onPostCreate(Bundle savedInstanceState, PersistableBundle persistentState) {
-    emitEvent(Event.POST_CREATE_PERSISTABLE, new BundleBundle(savedInstanceState, persistentState));
+    emitEvent(Event.POST_CREATE_PERSISTABLE, BundleBundle.create(savedInstanceState, persistentState));
   }
 
   public void onRequestPermissionsResult(int requestCode, String[] permissions,
       int[] grantResults) {
     emitEvent(Event.REQUEST_PERMISSIONS_RESULT,
-        new RequestPermissionsResult(requestCode, permissions, grantResults));
+        RequestPermissionsResult.create(requestCode, permissions, grantResults));
   }
 
   public void onRestart() {
@@ -228,7 +228,7 @@ public final class NaviEmitter implements NaviComponent {
 
   public void onRestoreInstanceState(Bundle savedInstanceState, PersistableBundle persistentState) {
     emitEvent(Event.RESTORE_INSTANCE_STATE_PERSISTABLE,
-        new BundleBundle(savedInstanceState, persistentState));
+        BundleBundle.create(savedInstanceState, persistentState));
   }
 
   public void onResume() {
@@ -241,7 +241,7 @@ public final class NaviEmitter implements NaviComponent {
 
   public void onSaveInstanceState(Bundle outState, PersistableBundle outPersistentState) {
     emitEvent(Event.SAVE_INSTANCE_STATE_PERSISTABLE,
-        new BundleBundle(outState, outPersistentState));
+        BundleBundle.create(outState, outPersistentState));
   }
 
   public void onStart() {

--- a/navi/src/main/java/com/trello/navi2/model/ActivityResult.java
+++ b/navi/src/main/java/com/trello/navi2/model/ActivityResult.java
@@ -2,54 +2,17 @@ package com.trello.navi2.model;
 
 import android.content.Intent;
 import android.support.annotation.Nullable;
+import com.google.auto.value.AutoValue;
 
-public final class ActivityResult {
+@AutoValue public abstract class ActivityResult {
 
-  private final int requestCode;
-  private final int resultCode;
-  private final Intent data;
-
-  public ActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
-    this.requestCode = requestCode;
-    this.resultCode = resultCode;
-    this.data = data;
+  public static ActivityResult create(int requestCode, int resultCode, @Nullable Intent data) {
+    return new AutoValue_ActivityResult(requestCode, resultCode, data);
   }
 
-  public int requestCode() {
-    return requestCode;
-  }
+  public abstract int requestCode();
 
-  public int resultCode() {
-    return resultCode;
-  }
+  public abstract int resultCode();
 
-  @Nullable public Intent data() {
-    return data;
-  }
-
-  @Override public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-
-    ActivityResult that = (ActivityResult) o;
-
-    if (requestCode != that.requestCode) return false;
-    if (resultCode != that.resultCode) return false;
-    return !(data != null ? !data.equals(that.data) : that.data != null);
-  }
-
-  @Override public int hashCode() {
-    int result = requestCode;
-    result = 31 * result + resultCode;
-    result = 31 * result + (data != null ? data.hashCode() : 0);
-    return result;
-  }
-
-  @Override public String toString() {
-    return "ActivityResult{" +
-        "requestCode=" + requestCode +
-        ", resultCode=" + resultCode +
-        ", data=" + data +
-        '}';
-  }
+  @Nullable public abstract Intent data();
 }

--- a/navi/src/main/java/com/trello/navi2/model/BundleBundle.java
+++ b/navi/src/main/java/com/trello/navi2/model/BundleBundle.java
@@ -3,49 +3,16 @@ package com.trello.navi2.model;
 import android.os.Bundle;
 import android.os.PersistableBundle;
 import android.support.annotation.Nullable;
+import com.google.auto.value.AutoValue;
 
-public final class BundleBundle {
+@AutoValue public abstract class BundleBundle {
 
-  private final Bundle bundle;
-
-  private final PersistableBundle persistableBundle;
-
-  public BundleBundle(@Nullable Bundle bundle, @Nullable PersistableBundle persistableBundle) {
-    this.bundle = bundle;
-    this.persistableBundle = persistableBundle;
+  public static BundleBundle create(@Nullable Bundle bundle,
+      @Nullable PersistableBundle persistableBundle) {
+    return new AutoValue_BundleBundle(bundle, persistableBundle);
   }
 
-  @Nullable
-  public Bundle bundle() {
-    return bundle;
-  }
+  @Nullable public abstract Bundle bundle();
 
-  @Nullable
-  public PersistableBundle persistableBundle() {
-    return persistableBundle;
-  }
-
-  @Override public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-
-    BundleBundle that = (BundleBundle) o;
-
-    if (bundle != null ? !bundle.equals(that.bundle) : that.bundle != null) return false;
-    return !(persistableBundle != null ? !persistableBundle.equals(that.persistableBundle)
-        : that.persistableBundle != null);
-  }
-
-  @Override public int hashCode() {
-    int result = bundle != null ? bundle.hashCode() : 0;
-    result = 31 * result + (persistableBundle != null ? persistableBundle.hashCode() : 0);
-    return result;
-  }
-
-  @Override public String toString() {
-    return "BundleBundle{" +
-        "bundle=" + bundle +
-        ", persistableBundle=" + persistableBundle +
-        '}';
-  }
+  @Nullable public abstract PersistableBundle persistableBundle();
 }

--- a/navi/src/main/java/com/trello/navi2/model/RequestPermissionsResult.java
+++ b/navi/src/main/java/com/trello/navi2/model/RequestPermissionsResult.java
@@ -1,57 +1,22 @@
 package com.trello.navi2.model;
 
 import android.support.annotation.NonNull;
+import com.google.auto.value.AutoValue;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
-public final class RequestPermissionsResult {
+@AutoValue public abstract class RequestPermissionsResult {
 
-  private final int requestCode;
-  private final String[] permissions;
-  private final int[] grantResults;
-
-  public RequestPermissionsResult(int requestCode, @NonNull String[] permissions,
+  public static RequestPermissionsResult create(int requestCode, @NonNull String[] permissions,
       @NonNull int[] grantResults) {
-    this.requestCode = requestCode;
-    this.permissions = permissions;
-    this.grantResults = grantResults;
+    return new AutoValue_RequestPermissionsResult(requestCode,
+        Collections.unmodifiableList(Arrays.asList(permissions)), grantResults);
   }
 
-  public int requestCode() {
-    return requestCode;
-  }
+  public abstract int requestCode();
 
-  @NonNull public String[] permissions() {
-    return permissions;
-  }
+  @NonNull public abstract List<String> permissions();
 
-  @NonNull public int[] grantResults() {
-    return grantResults;
-  }
-
-  @Override public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-
-    RequestPermissionsResult that = (RequestPermissionsResult) o;
-
-    if (requestCode != that.requestCode) return false;
-    // Probably incorrect - comparing Object[] arrays with Arrays.equals
-    if (!Arrays.equals(permissions, that.permissions)) return false;
-    return Arrays.equals(grantResults, that.grantResults);
-  }
-
-  @Override public int hashCode() {
-    int result = requestCode;
-    result = 31 * result + Arrays.hashCode(permissions);
-    result = 31 * result + Arrays.hashCode(grantResults);
-    return result;
-  }
-
-  @Override public String toString() {
-    return "RequestPermissionsResult{" +
-        "requestCode=" + requestCode +
-        ", permissions=" + Arrays.toString(permissions) +
-        ", grantResults=" + Arrays.toString(grantResults) +
-        '}';
-  }
+  @NonNull public abstract int[] grantResults();
 }

--- a/navi/src/main/java/com/trello/navi2/model/ViewCreated.java
+++ b/navi/src/main/java/com/trello/navi2/model/ViewCreated.java
@@ -1,48 +1,18 @@
 package com.trello.navi2.model;
 
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.view.View;
+import com.google.auto.value.AutoValue;
 
-public class ViewCreated {
-  private final Bundle bundle;
-  private final View view;
+@AutoValue public abstract class ViewCreated {
 
-  public ViewCreated(View view, @Nullable Bundle bundle) {
-    this.view = view;
-    this.bundle = bundle;
+  public static ViewCreated create(@NonNull View view, @Nullable Bundle bundle) {
+    return new AutoValue_ViewCreated(view, bundle);
   }
 
-  public View view() {
-    return view;
-  }
+  @NonNull public abstract View view();
 
-  @Nullable
-  public Bundle bundle() {
-    return bundle;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    ViewCreated that = (ViewCreated) o;
-    if (bundle != null ? !bundle.equals(that.bundle) : that.bundle != null) return false;
-    return view.equals(that.view);
-  }
-
-  @Override
-  public int hashCode() {
-    int result = bundle != null ? bundle.hashCode() : 0;
-    result = 31 * result + view.hashCode();
-    return result;
-  }
-
-  @Override
-  public String toString() {
-    return "ViewCreated{" +
-            "bundle=" + bundle +
-            ", view=" + view +
-            '}';
-  }
+  @Nullable public abstract Bundle bundle();
 }

--- a/navi/src/test/java/com/trello/navi2/NaviActivityTest.java
+++ b/navi/src/test/java/com/trello/navi2/NaviActivityTest.java
@@ -47,7 +47,7 @@ public final class NaviActivityTest {
     PersistableBundle persistableBundle = mock(PersistableBundle.class);
     emitter.onCreate(bundle, persistableBundle);
     verifyZeroInteractions(listener);
-    verify(persistableListener).call(new BundleBundle(bundle, persistableBundle));
+    verify(persistableListener).call(BundleBundle.create(bundle, persistableBundle));
 
     emitter.removeListener(listener);
     emitter.removeListener(persistableListener);
@@ -91,7 +91,7 @@ public final class NaviActivityTest {
     PersistableBundle persistableBundle = mock(PersistableBundle.class);
     emitter.onPostCreate(bundle, persistableBundle);
     verifyZeroInteractions(listener);
-    verify(persistableListener).call(new BundleBundle(bundle, persistableBundle));
+    verify(persistableListener).call(BundleBundle.create(bundle, persistableBundle));
 
     emitter.removeListener(listener);
     emitter.removeListener(persistableListener);
@@ -183,7 +183,7 @@ public final class NaviActivityTest {
     PersistableBundle persistableBundle = mock(PersistableBundle.class);
     emitter.onSaveInstanceState(bundle, persistableBundle);
     verifyZeroInteractions(listener);
-    verify(persistableListener).call(new BundleBundle(bundle, persistableBundle));
+    verify(persistableListener).call(BundleBundle.create(bundle, persistableBundle));
 
     emitter.removeListener(listener);
     emitter.removeListener(persistableListener);
@@ -215,7 +215,7 @@ public final class NaviActivityTest {
     PersistableBundle persistableBundle = mock(PersistableBundle.class);
     emitter.onRestoreInstanceState(bundle, persistableBundle);
     verifyZeroInteractions(listener);
-    verify(persistableListener).call(new BundleBundle(bundle, persistableBundle));
+    verify(persistableListener).call(BundleBundle.create(bundle, persistableBundle));
 
     emitter.removeListener(listener);
     emitter.removeListener(persistableListener);
@@ -294,7 +294,7 @@ public final class NaviActivityTest {
     int resultCode = Activity.RESULT_OK;
     Intent data = new Intent();
     emitter.onActivityResult(requestCode, resultCode, data);
-    verify(listener).call(new ActivityResult(requestCode, resultCode, data));
+    verify(listener).call(ActivityResult.create(requestCode, resultCode, data));
 
     emitter.removeListener(listener);
     emitter.onActivityResult(requestCode, resultCode, data);
@@ -309,7 +309,7 @@ public final class NaviActivityTest {
     String[] permissions = new String[0];
     int[] grantResults = new int[0];
     emitter.onRequestPermissionsResult(requestCode, permissions, grantResults);
-    verify(listener).call(new RequestPermissionsResult(requestCode, permissions, grantResults));
+    verify(listener).call(RequestPermissionsResult.create(requestCode, permissions, grantResults));
 
     emitter.removeListener(listener);
     emitter.onRequestPermissionsResult(requestCode, permissions, grantResults);

--- a/navi/src/test/java/com/trello/navi2/NaviFragmentTest.java
+++ b/navi/src/test/java/com/trello/navi2/NaviFragmentTest.java
@@ -88,7 +88,7 @@ public final class NaviFragmentTest {
     View view = mock(View.class);
     Bundle bundle = new Bundle();
     emitter.onViewCreated(view, bundle);
-    verify(listener).call(new ViewCreated(view, bundle));
+    verify(listener).call(ViewCreated.create(view, bundle));
 
     emitter.removeListener(listener);
     emitter.onCreate(new Bundle());
@@ -241,7 +241,7 @@ public final class NaviFragmentTest {
     int resultCode = Activity.RESULT_OK;
     Intent data = new Intent();
     emitter.onActivityResult(requestCode, resultCode, data);
-    verify(listener).call(new ActivityResult(requestCode, resultCode, data));
+    verify(listener).call(ActivityResult.create(requestCode, resultCode, data));
 
     emitter.removeListener(listener);
     emitter.onActivityResult(requestCode, resultCode, data);
@@ -256,7 +256,7 @@ public final class NaviFragmentTest {
     String[] permissions = new String[0];
     int[] grantResults = new int[0];
     emitter.onRequestPermissionsResult(requestCode, permissions, grantResults);
-    verify(listener).call(new RequestPermissionsResult(requestCode, permissions, grantResults));
+    verify(listener).call(RequestPermissionsResult.create(requestCode, permissions, grantResults));
 
     emitter.removeListener(listener);
     emitter.onRequestPermissionsResult(requestCode, permissions, grantResults);

--- a/navi/src/test/java/com/trello/navi2/rx/RxNaviActivityTest.java
+++ b/navi/src/test/java/com/trello/navi2/rx/RxNaviActivityTest.java
@@ -47,7 +47,7 @@ public final class RxNaviActivityTest {
     subscription.unsubscribe();
     emitter.onCreate(bundle, persistableBundle);
 
-    testSubscriber.assertValue(new BundleBundle(bundle, persistableBundle));
+    testSubscriber.assertValue(BundleBundle.create(bundle, persistableBundle));
     testSubscriber.assertNoTerminalEvent();
     testSubscriber.assertUnsubscribed();
   }
@@ -94,7 +94,7 @@ public final class RxNaviActivityTest {
     subscription.unsubscribe();
     emitter.onPostCreate(bundle, persistableBundle);
 
-    testSubscriber.assertValue(new BundleBundle(bundle, persistableBundle));
+    testSubscriber.assertValue(BundleBundle.create(bundle, persistableBundle));
     testSubscriber.assertNoTerminalEvent();
     testSubscriber.assertUnsubscribed();
   }
@@ -197,7 +197,7 @@ public final class RxNaviActivityTest {
     subscription.unsubscribe();
     emitter.onSaveInstanceState(bundle, persistableBundle);
 
-    testSubscriber.assertValue(new BundleBundle(bundle, persistableBundle));
+    testSubscriber.assertValue(BundleBundle.create(bundle, persistableBundle));
     testSubscriber.assertNoTerminalEvent();
     testSubscriber.assertUnsubscribed();
   }
@@ -230,7 +230,7 @@ public final class RxNaviActivityTest {
     subscription.unsubscribe();
     emitter.onRestoreInstanceState(bundle, persistableBundle);
 
-    testSubscriber.assertValue(new BundleBundle(bundle, persistableBundle));
+    testSubscriber.assertValue(BundleBundle.create(bundle, persistableBundle));
     testSubscriber.assertNoTerminalEvent();
     testSubscriber.assertUnsubscribed();
   }
@@ -325,7 +325,7 @@ public final class RxNaviActivityTest {
     subscription.unsubscribe();
     emitter.onActivityResult(requestCode, resultCode, data);
 
-    testSubscriber.assertValue(new ActivityResult(requestCode, resultCode, data));
+    testSubscriber.assertValue(ActivityResult.create(requestCode, resultCode, data));
     testSubscriber.assertNoTerminalEvent();
     testSubscriber.assertUnsubscribed();
   }
@@ -344,7 +344,7 @@ public final class RxNaviActivityTest {
     emitter.onRequestPermissionsResult(requestCode, permissions, grantResults);
 
     testSubscriber.assertValue(
-        new RequestPermissionsResult(requestCode, permissions, grantResults));
+        RequestPermissionsResult.create(requestCode, permissions, grantResults));
     testSubscriber.assertNoTerminalEvent();
     testSubscriber.assertUnsubscribed();
   }

--- a/navi/src/test/java/com/trello/navi2/rx/RxNaviFragmentTest.java
+++ b/navi/src/test/java/com/trello/navi2/rx/RxNaviFragmentTest.java
@@ -261,7 +261,7 @@ public final class RxNaviFragmentTest {
     subscription.unsubscribe();
     emitter.onActivityResult(requestCode, resultCode, data);
 
-    testSubscriber.assertValue(new ActivityResult(requestCode, resultCode, data));
+    testSubscriber.assertValue(ActivityResult.create(requestCode, resultCode, data));
     testSubscriber.assertNoTerminalEvent();
     testSubscriber.assertUnsubscribed();
   }
@@ -280,7 +280,7 @@ public final class RxNaviFragmentTest {
     emitter.onRequestPermissionsResult(requestCode, permissions, grantResults);
 
     testSubscriber.assertValue(
-        new RequestPermissionsResult(requestCode, permissions, grantResults));
+        RequestPermissionsResult.create(requestCode, permissions, grantResults));
     testSubscriber.assertNoTerminalEvent();
     testSubscriber.assertUnsubscribed();
   }


### PR DESCRIPTION
Moving to AutoValue makes the whole library more stable and also
simpler to maintain.

Only downside is that this changes the method signature on
RequestPermissionsResult.permissions(), since String[] is not allowed
in AutoValue classes.