### PR TITLE
Avoid usage of nulls in navi

### DIFF
--- a/navi/src/main/java/com/trello/navi2/Event.java
+++ b/navi/src/main/java/com/trello/navi2/Event.java
@@ -26,7 +26,8 @@ import com.trello.navi2.model.ViewCreated;
  * are called *before* their super calls are made. Events that are neither are called *after*
  * their super calls.
  *
- * @param <T> the callback type for the event
+ * @param <T> the callback type for the event. If Object, then the value is just a signal and has
+ * no contents.
  */
 public final class Event<T> {
 
@@ -50,7 +51,7 @@ public final class Event<T> {
   /**
    * Emits {@link Activity#onStart()} and {@link Fragment#onStart()}. Emitted after super().
    */
-  public static final Event<Void> START = new Event<>(Type.START, Void.class);
+  public static final Event<Object> START = new Event<>(Type.START, Object.class);
 
   /**
    * Emits {@link Activity#onPostCreate(Bundle)}. Emitted after super().
@@ -66,22 +67,22 @@ public final class Event<T> {
   /**
    * Emits {@link Activity#onResume()} and {@link Fragment#onResume()}. Emitted after super().
    */
-  public static final Event<Void> RESUME = new Event<>(Type.RESUME, Void.class);
+  public static final Event<Object> RESUME = new Event<>(Type.RESUME, Object.class);
 
   /**
    * Emits {@link Activity#onPause()} and {@link Fragment#onPause()}. Emitted before super().
    */
-  public static final Event<Void> PAUSE = new Event<>(Type.PAUSE, Void.class);
+  public static final Event<Object> PAUSE = new Event<>(Type.PAUSE, Object.class);
 
   /**
    * Emits {@link Activity#onStop()} and {@link Fragment#onStop()}. Emitted before super().
    */
-  public static final Event<Void> STOP = new Event<>(Type.STOP, Void.class);
+  public static final Event<Object> STOP = new Event<>(Type.STOP, Object.class);
 
   /**
    * Emits {@link Activity#onDestroy()} and {@link Fragment#onDestroy()}. Emitted before super().
    */
-  public static final Event<Void> DESTROY = new Event<>(Type.DESTROY, Void.class);
+  public static final Event<Object> DESTROY = new Event<>(Type.DESTROY, Object.class);
 
   /**
    * Emits {@link Activity#onSaveInstanceState(Bundle)} and
@@ -120,7 +121,7 @@ public final class Event<T> {
   /**
    * Emits {@link Activity#onRestart()}. Emitted after super().
    */
-  public static final Event<Void> RESTART = new Event<>(Type.RESTART, Void.class);
+  public static final Event<Object> RESTART = new Event<>(Type.RESTART, Object.class);
 
   /**
    * Emits {@link Activity#onRestoreInstanceState(Bundle)}. Emitted after super().
@@ -143,19 +144,19 @@ public final class Event<T> {
   /**
    * Emits {@link Activity#onBackPressed()}. Emitted after super().
    */
-  public static final Event<Void> BACK_PRESSED = new Event<>(Type.BACK_PRESSED, Void.class);
+  public static final Event<Object> BACK_PRESSED = new Event<>(Type.BACK_PRESSED, Object.class);
 
   /**
    * Emits {@link Activity#onAttachedToWindow()}. Emitted after super().
    */
-  public static final Event<Void> ATTACHED_TO_WINDOW =
-      new Event<>(Type.ATTACHED_TO_WINDOW, Void.class);
+  public static final Event<Object> ATTACHED_TO_WINDOW =
+      new Event<>(Type.ATTACHED_TO_WINDOW, Object.class);
 
   /**
    * Emits {@link Activity#onDetachedFromWindow()}. Emitted after super().
    */
-  public static final Event<Void> DETACHED_FROM_WINDOW =
-      new Event<>(Type.DETACHED_FROM_WINDOW, Void.class);
+  public static final Event<Object> DETACHED_FROM_WINDOW =
+      new Event<>(Type.DETACHED_FROM_WINDOW, Object.class);
 
   /**
    * Emits {@link Fragment#onAttach(Context)}. Emitted after super().
@@ -187,12 +188,12 @@ public final class Event<T> {
   /**
    * Emits {@link Fragment#onDestroyView()}. Emitted before super().
    */
-  public static final Event<Void> DESTROY_VIEW = new Event<>(Type.DESTROY_VIEW, Void.class);
+  public static final Event<Object> DESTROY_VIEW = new Event<>(Type.DESTROY_VIEW, Object.class);
 
   /**
    * Emits {@link Fragment#onDetach()}. Emitted before super().
    */
-  public static final Event<Void> DETACH = new Event<>(Type.DETACH, Void.class);
+  public static final Event<Object> DETACH = new Event<>(Type.DETACH, Object.class);
 
   private final Type eventType;
 

--- a/navi/src/main/java/com/trello/navi2/Event.java
+++ b/navi/src/main/java/com/trello/navi2/Event.java
@@ -7,6 +7,7 @@ import android.content.Intent;
 import android.content.res.Configuration;
 import android.os.Bundle;
 import android.os.PersistableBundle;
+import android.support.annotation.NonNull;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -200,7 +201,7 @@ public final class Event<T> {
   private final Class<T> callbackType;
 
   // This is purposefully hidden so that we can control available events
-  private Event(Type eventType, Class<T> callbackType) {
+  private Event(@NonNull Type eventType, @NonNull Class<T> callbackType) {
     this.eventType = eventType;
     this.callbackType = callbackType;
   }

--- a/navi/src/main/java/com/trello/navi2/Listener.java
+++ b/navi/src/main/java/com/trello/navi2/Listener.java
@@ -1,10 +1,12 @@
 package com.trello.navi2;
 
+import android.support.annotation.NonNull;
+
 /**
  * Listener callback.
  *
  * @param <T> the callback type; can be Void in cases where event has no metadata
  */
 public interface Listener<T> {
-  void call(T t);
+  void call(@NonNull T t);
 }

--- a/navi/src/main/java/com/trello/navi2/NaviComponent.java
+++ b/navi/src/main/java/com/trello/navi2/NaviComponent.java
@@ -1,5 +1,7 @@
 package com.trello.navi2;
 
+import android.support.annotation.NonNull;
+
 /**
  * Represents an Android component (Activity, Fragment) that can have listeners.
  */
@@ -23,14 +25,13 @@ public interface NaviComponent {
    * @param <T> the callback type for the event
    * @throws IllegalArgumentException if this component cannot handle the event
    */
-  <T> void addListener(Event<T> event, Listener<T> listener);
+  <T> void addListener(@NonNull Event<T> event, @NonNull Listener<T> listener);
 
   /**
    * Removes a listener from this component.
    *
    * @param <T> the callback type for the event
    * @param listener the listener for that event
-   * @throws IllegalArgumentException if this component cannot handle the event
    */
-  <T> void removeListener(Listener<T> listener);
+  <T> void removeListener(@NonNull Listener<T> listener);
 }

--- a/navi/src/main/java/com/trello/navi2/component/NaviActivity.java
+++ b/navi/src/main/java/com/trello/navi2/component/NaviActivity.java
@@ -20,11 +20,11 @@ public class NaviActivity extends Activity implements NaviComponent {
     return base.handlesEvents(events);
   }
 
-  @Override public final <T> void addListener(Event<T> event, Listener<T> listener) {
+  @Override public final <T> void addListener(@NonNull Event<T> event, @NonNull Listener<T> listener) {
     base.addListener(event, listener);
   }
 
-  @Override public final <T> void removeListener(Listener<T> listener) {
+  @Override public final <T> void removeListener(@NonNull Listener<T> listener) {
     base.removeListener(listener);
   }
 

--- a/navi/src/main/java/com/trello/navi2/component/NaviDialogFragment.java
+++ b/navi/src/main/java/com/trello/navi2/component/NaviDialogFragment.java
@@ -25,11 +25,11 @@ public class NaviDialogFragment extends DialogFragment implements NaviComponent 
     return base.handlesEvents(events);
   }
 
-  @Override public final <T> void addListener(Event<T> event, Listener<T> listener) {
+  @Override public final <T> void addListener(@NonNull Event<T> event, @NonNull Listener<T> listener) {
     base.addListener(event, listener);
   }
 
-  @Override public final <T> void removeListener(Listener<T> listener) {
+  @Override public final <T> void removeListener(@NonNull Listener<T> listener) {
     base.removeListener(listener);
   }
 

--- a/navi/src/main/java/com/trello/navi2/component/NaviFragment.java
+++ b/navi/src/main/java/com/trello/navi2/component/NaviFragment.java
@@ -25,11 +25,11 @@ public class NaviFragment extends Fragment implements NaviComponent {
     return base.handlesEvents(events);
   }
 
-  @Override public final <T> void addListener(Event<T> event, Listener<T> listener) {
+  @Override public final <T> void addListener(@NonNull Event<T> event, @NonNull Listener<T> listener) {
     base.addListener(event, listener);
   }
 
-  @Override public final <T> void removeListener(Listener<T> listener) {
+  @Override public final <T> void removeListener(@NonNull Listener<T> listener) {
     base.removeListener(listener);
   }
 

--- a/navi/src/main/java/com/trello/navi2/component/support/NaviAppCompatActivity.java
+++ b/navi/src/main/java/com/trello/navi2/component/support/NaviAppCompatActivity.java
@@ -21,11 +21,11 @@ public class NaviAppCompatActivity extends AppCompatActivity implements NaviComp
     return base.handlesEvents(events);
   }
 
-  @Override public final <T> void addListener(Event<T> event, Listener<T> listener) {
+  @Override public final <T> void addListener(@NonNull Event<T> event, @NonNull Listener<T> listener) {
     base.addListener(event, listener);
   }
 
-  @Override public final <T> void removeListener(Listener<T> listener) {
+  @Override public final <T> void removeListener(@NonNull Listener<T> listener) {
     base.removeListener(listener);
   }
 

--- a/navi/src/main/java/com/trello/navi2/component/support/NaviAppCompatDialogFragment.java
+++ b/navi/src/main/java/com/trello/navi2/component/support/NaviAppCompatDialogFragment.java
@@ -25,11 +25,11 @@ public class NaviAppCompatDialogFragment extends DialogFragment implements NaviC
     return base.handlesEvents(events);
   }
 
-  @Override public final <T> void addListener(Event<T> event, Listener<T> listener) {
+  @Override public final <T> void addListener(@NonNull Event<T> event, @NonNull Listener<T> listener) {
     base.addListener(event, listener);
   }
 
-  @Override public final <T> void removeListener(Listener<T> listener) {
+  @Override public final <T> void removeListener(@NonNull Listener<T> listener) {
     base.removeListener(listener);
   }
 

--- a/navi/src/main/java/com/trello/navi2/component/support/NaviDialogFragment.java
+++ b/navi/src/main/java/com/trello/navi2/component/support/NaviDialogFragment.java
@@ -25,11 +25,11 @@ public class NaviDialogFragment extends DialogFragment implements NaviComponent 
     return base.handlesEvents(events);
   }
 
-  @Override public final <T> void addListener(Event<T> event, Listener<T> listener) {
+  @Override public final <T> void addListener(@NonNull Event<T> event, @NonNull Listener<T> listener) {
     base.addListener(event, listener);
   }
 
-  @Override public final <T> void removeListener(Listener<T> listener) {
+  @Override public final <T> void removeListener(@NonNull Listener<T> listener) {
     base.removeListener(listener);
   }
 

--- a/navi/src/main/java/com/trello/navi2/component/support/NaviFragment.java
+++ b/navi/src/main/java/com/trello/navi2/component/support/NaviFragment.java
@@ -25,11 +25,11 @@ public class NaviFragment extends Fragment implements NaviComponent {
     return base.handlesEvents(events);
   }
 
-  @Override public final <T> void addListener(Event<T> event, Listener<T> listener) {
+  @Override public final <T> void addListener(@NonNull Event<T> event, @NonNull Listener<T> listener) {
     base.addListener(event, listener);
   }
 
-  @Override public final <T> void removeListener(Listener<T> listener) {
+  @Override public final <T> void removeListener(@NonNull Listener<T> listener) {
     base.removeListener(listener);
   }
 

--- a/navi/src/main/java/com/trello/navi2/internal/Constants.java
+++ b/navi/src/main/java/com/trello/navi2/internal/Constants.java
@@ -1,0 +1,15 @@
+package com.trello.navi2.internal;
+
+final class Constants {
+
+  /**
+   * Acts as a signal for events that have no data associated with them.
+   *
+   * We reuse a single Object to avoid any extra allocations.
+   */
+  static final Object SIGNAL = new Object();
+
+  private Constants() {
+    throw new AssertionError("No instances!");
+  }
+}

--- a/navi/src/main/java/com/trello/navi2/internal/NaviEmitter.java
+++ b/navi/src/main/java/com/trello/navi2/internal/NaviEmitter.java
@@ -137,7 +137,8 @@ public final class NaviEmitter implements NaviComponent {
   // Events
 
   public void onActivityCreated(@Nullable Bundle savedInstanceState) {
-    emitEvent(Event.ACTIVITY_CREATED, savedInstanceState);
+    emitEvent(Event.ACTIVITY_CREATED,
+        savedInstanceState != null ? savedInstanceState : new Bundle());
   }
 
   public void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
@@ -169,7 +170,7 @@ public final class NaviEmitter implements NaviComponent {
   }
 
   public void onCreate(@Nullable Bundle savedInstanceState) {
-    emitEvent(Event.CREATE, savedInstanceState);
+    emitEvent(Event.CREATE, savedInstanceState != null ? savedInstanceState : new Bundle());
   }
 
   public void onCreate(@Nullable Bundle savedInstanceState,
@@ -178,7 +179,7 @@ public final class NaviEmitter implements NaviComponent {
   }
 
   public void onCreateView(@Nullable Bundle savedInstanceState) {
-    emitEvent(Event.CREATE_VIEW, savedInstanceState);
+    emitEvent(Event.CREATE_VIEW, savedInstanceState != null ? savedInstanceState : new Bundle());
   }
 
   public void onViewCreated(@NonNull View view, @Nullable Bundle bundle) {
@@ -210,7 +211,7 @@ public final class NaviEmitter implements NaviComponent {
   }
 
   public void onPostCreate(@Nullable Bundle savedInstanceState) {
-    emitEvent(Event.POST_CREATE, savedInstanceState);
+    emitEvent(Event.POST_CREATE, savedInstanceState != null ? savedInstanceState : new Bundle());
   }
 
   public void onPostCreate(@Nullable Bundle savedInstanceState,
@@ -230,7 +231,8 @@ public final class NaviEmitter implements NaviComponent {
   }
 
   public void onRestoreInstanceState(@Nullable Bundle savedInstanceState) {
-    emitEvent(Event.RESTORE_INSTANCE_STATE, savedInstanceState);
+    emitEvent(Event.RESTORE_INSTANCE_STATE,
+        savedInstanceState != null ? savedInstanceState : new Bundle());
   }
 
   public void onRestoreInstanceState(@Nullable Bundle savedInstanceState,
@@ -262,6 +264,7 @@ public final class NaviEmitter implements NaviComponent {
   }
 
   public void onViewStateRestored(@Nullable Bundle savedInstanceState) {
-    emitEvent(Event.VIEW_STATE_RESTORED, savedInstanceState);
+    emitEvent(Event.VIEW_STATE_RESTORED,
+        savedInstanceState != null ? savedInstanceState : new Bundle());
   }
 }

--- a/navi/src/main/java/com/trello/navi2/internal/NaviEmitter.java
+++ b/navi/src/main/java/com/trello/navi2/internal/NaviEmitter.java
@@ -8,6 +8,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.PersistableBundle;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.view.View;
 import com.trello.navi2.Event;
 import com.trello.navi2.Event.Type;
@@ -69,7 +70,8 @@ public final class NaviEmitter implements NaviComponent {
     return true;
   }
 
-  @Override public final <T> void addListener(Event<T> event, Listener<T> listener) {
+  @Override
+  public final <T> void addListener(@NonNull Event<T> event, @NonNull Listener<T> listener) {
     if (!handlesEvents(event)) {
       throw new IllegalArgumentException("This component cannot handle event " + event);
     }
@@ -95,18 +97,18 @@ public final class NaviEmitter implements NaviComponent {
     listeners.add(listener);
   }
 
-  @Override public final <T> void removeListener(Listener<T> listener) {
+  @Override public final <T> void removeListener(@NonNull Listener<T> listener) {
     final Event event = eventMap.remove(listener);
     if (event != null && listenerMap.containsKey(event)) {
       listenerMap.get(event).remove(listener);
     }
   }
 
-  private void emitEvent(Event<Object> event) {
+  private void emitEvent(@NonNull Event<Object> event) {
     emitEvent(event, SIGNAL);
   }
 
-  private <T> void emitEvent(Event<T> event, T data) {
+  private <T> void emitEvent(@NonNull Event<T> event, @NonNull T data) {
     // We gather listener iterators  all at once so adding/removing listeners during emission
     // doesn't change the listener list.
     final List<Listener> listeners = listenerMap.get(event);
@@ -134,21 +136,21 @@ public final class NaviEmitter implements NaviComponent {
   ////////////////////////////////////////////////////////////////////////////
   // Events
 
-  public void onActivityCreated(Bundle savedInstanceState) {
+  public void onActivityCreated(@Nullable Bundle savedInstanceState) {
     emitEvent(Event.ACTIVITY_CREATED, savedInstanceState);
   }
 
-  public void onActivityResult(int requestCode, int resultCode, Intent data) {
+  public void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
     emitEvent(Event.ACTIVITY_RESULT, ActivityResult.create(requestCode, resultCode, data));
   }
 
-  public void onAttach(Activity activity) {
+  public void onAttach(@NonNull Activity activity) {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
       emitEvent(Event.ATTACH, activity);
     }
   }
 
-  public void onAttach(Context context) {
+  public void onAttach(@NonNull Context context) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
       emitEvent(Event.ATTACH, context);
     }
@@ -162,23 +164,24 @@ public final class NaviEmitter implements NaviComponent {
     emitEvent(Event.BACK_PRESSED);
   }
 
-  public void onConfigurationChanged(Configuration newConfig) {
+  public void onConfigurationChanged(@NonNull Configuration newConfig) {
     emitEvent(Event.CONFIGURATION_CHANGED, newConfig);
   }
 
-  public void onCreate(Bundle savedInstanceState) {
+  public void onCreate(@Nullable Bundle savedInstanceState) {
     emitEvent(Event.CREATE, savedInstanceState);
   }
 
-  public void onCreate(Bundle savedInstanceState, PersistableBundle persistentState) {
+  public void onCreate(@Nullable Bundle savedInstanceState,
+      @Nullable PersistableBundle persistentState) {
     emitEvent(Event.CREATE_PERSISTABLE, BundleBundle.create(savedInstanceState, persistentState));
   }
 
-  public void onCreateView(Bundle savedInstanceState) {
+  public void onCreateView(@Nullable Bundle savedInstanceState) {
     emitEvent(Event.CREATE_VIEW, savedInstanceState);
   }
 
-  public void onViewCreated(View view, Bundle bundle) {
+  public void onViewCreated(@NonNull View view, @Nullable Bundle bundle) {
     emitEvent(Event.VIEW_CREATED, ViewCreated.create(view, bundle));
   }
 
@@ -198,7 +201,7 @@ public final class NaviEmitter implements NaviComponent {
     emitEvent(Event.DETACHED_FROM_WINDOW);
   }
 
-  public void onNewIntent(Intent intent) {
+  public void onNewIntent(@NonNull Intent intent) {
     emitEvent(Event.NEW_INTENT, intent);
   }
 
@@ -206,16 +209,18 @@ public final class NaviEmitter implements NaviComponent {
     emitEvent(Event.PAUSE);
   }
 
-  public void onPostCreate(Bundle savedInstanceState) {
+  public void onPostCreate(@Nullable Bundle savedInstanceState) {
     emitEvent(Event.POST_CREATE, savedInstanceState);
   }
 
-  public void onPostCreate(Bundle savedInstanceState, PersistableBundle persistentState) {
-    emitEvent(Event.POST_CREATE_PERSISTABLE, BundleBundle.create(savedInstanceState, persistentState));
+  public void onPostCreate(@Nullable Bundle savedInstanceState,
+      @Nullable PersistableBundle persistentState) {
+    emitEvent(Event.POST_CREATE_PERSISTABLE,
+        BundleBundle.create(savedInstanceState, persistentState));
   }
 
-  public void onRequestPermissionsResult(int requestCode, String[] permissions,
-      int[] grantResults) {
+  public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
+      @NonNull int[] grantResults) {
     emitEvent(Event.REQUEST_PERMISSIONS_RESULT,
         RequestPermissionsResult.create(requestCode, permissions, grantResults));
   }
@@ -224,11 +229,12 @@ public final class NaviEmitter implements NaviComponent {
     emitEvent(Event.RESTART);
   }
 
-  public void onRestoreInstanceState(Bundle savedInstanceState) {
+  public void onRestoreInstanceState(@Nullable Bundle savedInstanceState) {
     emitEvent(Event.RESTORE_INSTANCE_STATE, savedInstanceState);
   }
 
-  public void onRestoreInstanceState(Bundle savedInstanceState, PersistableBundle persistentState) {
+  public void onRestoreInstanceState(@Nullable Bundle savedInstanceState,
+      @Nullable PersistableBundle persistentState) {
     emitEvent(Event.RESTORE_INSTANCE_STATE_PERSISTABLE,
         BundleBundle.create(savedInstanceState, persistentState));
   }
@@ -237,11 +243,12 @@ public final class NaviEmitter implements NaviComponent {
     emitEvent(Event.RESUME);
   }
 
-  public void onSaveInstanceState(Bundle outState) {
+  public void onSaveInstanceState(@NonNull Bundle outState) {
     emitEvent(Event.SAVE_INSTANCE_STATE, outState);
   }
 
-  public void onSaveInstanceState(Bundle outState, PersistableBundle outPersistentState) {
+  public void onSaveInstanceState(@NonNull Bundle outState,
+      @NonNull PersistableBundle outPersistentState) {
     emitEvent(Event.SAVE_INSTANCE_STATE_PERSISTABLE,
         BundleBundle.create(outState, outPersistentState));
   }
@@ -254,7 +261,7 @@ public final class NaviEmitter implements NaviComponent {
     emitEvent(Event.STOP);
   }
 
-  public void onViewStateRestored(Bundle savedInstanceState) {
+  public void onViewStateRestored(@Nullable Bundle savedInstanceState) {
     emitEvent(Event.VIEW_STATE_RESTORED, savedInstanceState);
   }
 }

--- a/navi/src/main/java/com/trello/navi2/internal/NaviEmitter.java
+++ b/navi/src/main/java/com/trello/navi2/internal/NaviEmitter.java
@@ -27,6 +27,8 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import static com.trello.navi2.internal.Constants.SIGNAL;
+
 /**
  * Emitter of Navi events which contains all the actual logic
  *
@@ -100,8 +102,8 @@ public final class NaviEmitter implements NaviComponent {
     }
   }
 
-  private void emitEvent(Event<Void> event) {
-    emitEvent(event, null);
+  private void emitEvent(Event<Object> event) {
+    emitEvent(event, SIGNAL);
   }
 
   private <T> void emitEvent(Event<T> event, T data) {

--- a/navi/src/main/java/com/trello/navi2/rx/NaviOnSubscribe.java
+++ b/navi/src/main/java/com/trello/navi2/rx/NaviOnSubscribe.java
@@ -1,5 +1,6 @@
 package com.trello.navi2.rx;
 
+import android.support.annotation.NonNull;
 import com.trello.navi2.Event;
 import com.trello.navi2.Listener;
 import com.trello.navi2.NaviComponent;
@@ -21,7 +22,7 @@ final class NaviOnSubscribe<T> implements Observable.OnSubscribe<T> {
 
   @Override public void call(final Subscriber<? super T> subscriber) {
     final Listener<T> listener = new Listener<T>() {
-      @Override public void call(T t) {
+      @Override public void call(@NonNull T t) {
         if (!subscriber.isUnsubscribed()) {
           subscriber.onNext(t);
         }

--- a/navi/src/test/java/com/trello/navi2/AddRemoveTest.java
+++ b/navi/src/test/java/com/trello/navi2/AddRemoveTest.java
@@ -6,6 +6,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -16,20 +17,20 @@ public class AddRemoveTest {
 
   @Test public void add() {
     NaviEmitter emitter = NaviEmitter.createActivityEmitter();
-    Listener<Void> listener = mock(Listener.class);
+    Listener<Object> listener = mock(Listener.class);
     emitter.addListener(Event.START, listener);
     emitter.onStart();
-    verify(listener).call(null);
+    verify(listener).call(any());
   }
 
   // Allowed, but idempotent
   @Test public void doubleAdd() {
     NaviEmitter emitter = NaviEmitter.createActivityEmitter();
-    Listener<Void> listener = mock(Listener.class);
+    Listener<Object> listener = mock(Listener.class);
     emitter.addListener(Event.START, listener);
     emitter.addListener(Event.START, listener);
     emitter.onStart();
-    verify(listener).call(null);
+    verify(listener).call(any());
   }
 
   // Not allowed
@@ -43,7 +44,7 @@ public class AddRemoveTest {
 
   @Test public void remove() {
     NaviEmitter emitter = NaviEmitter.createActivityEmitter();
-    Listener<Void> listener = mock(Listener.class);
+    Listener<Object> listener = mock(Listener.class);
     emitter.addListener(Event.START, listener);
     emitter.removeListener(listener);
     emitter.onStart();
@@ -53,7 +54,7 @@ public class AddRemoveTest {
   // Dumb, but allowed
   @Test public void doubleRemove() {
     NaviEmitter emitter = NaviEmitter.createActivityEmitter();
-    Listener<Void> listener = mock(Listener.class);
+    Listener<Object> listener = mock(Listener.class);
     emitter.addListener(Event.START, listener);
     emitter.removeListener(listener);
     emitter.removeListener(listener);

--- a/navi/src/test/java/com/trello/navi2/ConcurrencyTest.java
+++ b/navi/src/test/java/com/trello/navi2/ConcurrencyTest.java
@@ -4,6 +4,7 @@ import com.trello.navi2.Event.Type;
 import com.trello.navi2.internal.NaviEmitter;
 import org.junit.Test;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -15,13 +16,13 @@ public final class ConcurrencyTest {
 
   // Verify that we can handle a listener removing itself due to an event occurring
   @Test public void handleInnerRemovals() {
-    final Listener<Void> listener1 = spy(new Listener<Void>() {
-      @Override public void call(Void __) {
+    final Listener<Object> listener1 = spy(new Listener<Object>() {
+      @Override public void call(Object __) {
         emitter.removeListener(this);
       }
     });
-    final Listener<Void> listener2 = spy(new Listener<Void>() {
-      @Override public void call(Void __) {
+    final Listener<Object> listener2 = spy(new Listener<Object>() {
+      @Override public void call(Object __) {
         emitter.removeListener(this);
       }
     });
@@ -29,16 +30,16 @@ public final class ConcurrencyTest {
     emitter.addListener(Event.RESUME, listener1);
     emitter.addListener(Event.RESUME, listener2);
     emitter.onResume();
-    verify(listener1).call(null);
-    verify(listener2).call(null);
+    verify(listener1).call(any());
+    verify(listener2).call(any());
   }
 
   // Verify that listeners added while emitting an item do not also get the current emission
   // (since they were not registered at the time of the event).
   @Test public void addDuringEmit() {
-    final Listener<Void> addedDuringEmit = mock(Listener.class);
-    final Listener<Void> listener = spy(new Listener<Void>() {
-      @Override public void call(Void __) {
+    final Listener<Object> addedDuringEmit = mock(Listener.class);
+    final Listener<Object> listener = spy(new Listener<Object>() {
+      @Override public void call(Object __) {
         emitter.addListener(Event.RESUME, addedDuringEmit);
       }
     });
@@ -46,7 +47,7 @@ public final class ConcurrencyTest {
     emitter.addListener(Event.RESUME, listener);
     emitter.onResume();
 
-    verify(listener).call(null);
+    verify(listener).call(any());
     verifyZeroInteractions(addedDuringEmit);
   }
 
@@ -54,8 +55,8 @@ public final class ConcurrencyTest {
   // doesn't cause it to get the current emission
   @Test public void addAllDuringEmit() {
     final Listener<Type> addedDuringEmit = mock(Listener.class);
-    final Listener<Void> listener = spy(new Listener<Void>() {
-      @Override public void call(Void aVoid) {
+    final Listener<Object> listener = spy(new Listener<Object>() {
+      @Override public void call(Object aVoid) {
         emitter.addListener(Event.ALL, addedDuringEmit);
       }
     });
@@ -63,14 +64,14 @@ public final class ConcurrencyTest {
     emitter.addListener(Event.RESUME, listener);
     emitter.onResume();
 
-    verify(listener).call(null);
+    verify(listener).call(any());
     verifyZeroInteractions(addedDuringEmit);
   }
 
   // Verify that adding a listener during an ALL emission
   // doesn't cause it to get the current emission
   @Test public void addDuringEmitAll() {
-    final Listener<Void> addedDuringEmit = mock(Listener.class);
+    final Listener<Object> addedDuringEmit = mock(Listener.class);
     final Listener<Type> listener = spy(new Listener<Type>() {
       @Override public void call(Type type) {
         emitter.addListener(Event.RESUME, addedDuringEmit);
@@ -87,9 +88,9 @@ public final class ConcurrencyTest {
   // Verify that listeners removed while emitting an event still receive it (since they were
   // registered at the time of the event).
   @Test public void removeDuringEmit() {
-    final Listener<Void> removedDuringEmit = mock(Listener.class);
-    final Listener<Void> listener = spy(new Listener<Void>() {
-      @Override public void call(Void __) {
+    final Listener<Object> removedDuringEmit = mock(Listener.class);
+    final Listener<Object> listener = spy(new Listener<Object>() {
+      @Override public void call(Object __) {
         emitter.removeListener(removedDuringEmit);
       }
     });
@@ -98,16 +99,16 @@ public final class ConcurrencyTest {
     emitter.addListener(Event.RESUME, removedDuringEmit);
     emitter.onResume();
 
-    verify(listener).call(null);
-    verify(removedDuringEmit).call(null);
+    verify(listener).call(any());
+    verify(removedDuringEmit).call(any());
   }
 
   // Verify that removing an ALL listener during emission
   // doesn't cause it to lose the current emission
   @Test public void removeAllDuringEmit() {
     final Listener<Type> removedDuringEmit = mock(Listener.class);
-    final Listener<Void> listener = spy(new Listener<Void>() {
-      @Override public void call(Void __) {
+    final Listener<Object> listener = spy(new Listener<Object>() {
+      @Override public void call(Object __) {
         emitter.removeListener(removedDuringEmit);
       }
     });
@@ -116,14 +117,14 @@ public final class ConcurrencyTest {
     emitter.addListener(Event.ALL, removedDuringEmit);
     emitter.onResume();
 
-    verify(listener).call(null);
+    verify(listener).call(any());
     verify(removedDuringEmit).call(Type.RESUME);
   }
 
   // Verify that removing a listener during an ALL emission
   // doesn't cause it to lose the current emission
   @Test public void removeDuringEmitAll() {
-    final Listener<Void> removedDuringEmit = mock(Listener.class);
+    final Listener<Object> removedDuringEmit = mock(Listener.class);
     final Listener<Type> listener = spy(new Listener<Type>() {
       @Override public void call(Type type) {
         emitter.removeListener(removedDuringEmit);
@@ -135,6 +136,6 @@ public final class ConcurrencyTest {
     emitter.onResume();
 
     verify(listener).call(Type.RESUME);
-    verify(removedDuringEmit).call(null);
+    verify(removedDuringEmit).call(any());
   }
 }

--- a/navi/src/test/java/com/trello/navi2/ConcurrencyTest.java
+++ b/navi/src/test/java/com/trello/navi2/ConcurrencyTest.java
@@ -1,5 +1,6 @@
 package com.trello.navi2;
 
+import android.support.annotation.NonNull;
 import com.trello.navi2.Event.Type;
 import com.trello.navi2.internal.NaviEmitter;
 import org.junit.Test;
@@ -17,12 +18,12 @@ public final class ConcurrencyTest {
   // Verify that we can handle a listener removing itself due to an event occurring
   @Test public void handleInnerRemovals() {
     final Listener<Object> listener1 = spy(new Listener<Object>() {
-      @Override public void call(Object __) {
+      @Override public void call(@NonNull Object __) {
         emitter.removeListener(this);
       }
     });
     final Listener<Object> listener2 = spy(new Listener<Object>() {
-      @Override public void call(Object __) {
+      @Override public void call(@NonNull Object __) {
         emitter.removeListener(this);
       }
     });
@@ -39,7 +40,7 @@ public final class ConcurrencyTest {
   @Test public void addDuringEmit() {
     final Listener<Object> addedDuringEmit = mock(Listener.class);
     final Listener<Object> listener = spy(new Listener<Object>() {
-      @Override public void call(Object __) {
+      @Override public void call(@NonNull Object __) {
         emitter.addListener(Event.RESUME, addedDuringEmit);
       }
     });
@@ -56,7 +57,7 @@ public final class ConcurrencyTest {
   @Test public void addAllDuringEmit() {
     final Listener<Type> addedDuringEmit = mock(Listener.class);
     final Listener<Object> listener = spy(new Listener<Object>() {
-      @Override public void call(Object aVoid) {
+      @Override public void call(@NonNull Object aVoid) {
         emitter.addListener(Event.ALL, addedDuringEmit);
       }
     });
@@ -73,7 +74,7 @@ public final class ConcurrencyTest {
   @Test public void addDuringEmitAll() {
     final Listener<Object> addedDuringEmit = mock(Listener.class);
     final Listener<Type> listener = spy(new Listener<Type>() {
-      @Override public void call(Type type) {
+      @Override public void call(@NonNull Type type) {
         emitter.addListener(Event.RESUME, addedDuringEmit);
       }
     });
@@ -90,7 +91,7 @@ public final class ConcurrencyTest {
   @Test public void removeDuringEmit() {
     final Listener<Object> removedDuringEmit = mock(Listener.class);
     final Listener<Object> listener = spy(new Listener<Object>() {
-      @Override public void call(Object __) {
+      @Override public void call(@NonNull Object __) {
         emitter.removeListener(removedDuringEmit);
       }
     });
@@ -108,7 +109,7 @@ public final class ConcurrencyTest {
   @Test public void removeAllDuringEmit() {
     final Listener<Type> removedDuringEmit = mock(Listener.class);
     final Listener<Object> listener = spy(new Listener<Object>() {
-      @Override public void call(Object __) {
+      @Override public void call(@NonNull Object __) {
         emitter.removeListener(removedDuringEmit);
       }
     });
@@ -126,7 +127,7 @@ public final class ConcurrencyTest {
   @Test public void removeDuringEmitAll() {
     final Listener<Object> removedDuringEmit = mock(Listener.class);
     final Listener<Type> listener = spy(new Listener<Type>() {
-      @Override public void call(Type type) {
+      @Override public void call(@NonNull Type type) {
         emitter.removeListener(removedDuringEmit);
       }
     });

--- a/navi/src/test/java/com/trello/navi2/NaviActivityTest.java
+++ b/navi/src/test/java/com/trello/navi2/NaviActivityTest.java
@@ -13,6 +13,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -57,11 +58,11 @@ public final class NaviActivityTest {
   }
 
   @Test public void startListener() {
-    Listener<Void> listener = mock(Listener.class);
+    Listener<Object> listener = mock(Listener.class);
     emitter.addListener(Event.START, listener);
 
     emitter.onStart();
-    verify(listener).call(null);
+    verify(listener).call(any());
 
     emitter.removeListener(listener);
     emitter.onStart();
@@ -101,11 +102,11 @@ public final class NaviActivityTest {
   }
 
   @Test public void resumeListener() {
-    Listener<Void> listener = mock(Listener.class);
+    Listener<Object> listener = mock(Listener.class);
     emitter.addListener(Event.RESUME, listener);
 
     emitter.onResume();
-    verify(listener).call(null);
+    verify(listener).call(any());
 
     emitter.removeListener(listener);
     emitter.onResume();
@@ -113,11 +114,11 @@ public final class NaviActivityTest {
   }
 
   @Test public void pauseListener() {
-    Listener<Void> listener = mock(Listener.class);
+    Listener<Object> listener = mock(Listener.class);
     emitter.addListener(Event.PAUSE, listener);
 
     emitter.onPause();
-    verify(listener).call(null);
+    verify(listener).call(any());
 
     emitter.removeListener(listener);
     emitter.onPause();
@@ -125,11 +126,11 @@ public final class NaviActivityTest {
   }
 
   @Test public void stopListener() {
-    Listener<Void> listener = mock(Listener.class);
+    Listener<Object> listener = mock(Listener.class);
     emitter.addListener(Event.STOP, listener);
 
     emitter.onStop();
-    verify(listener).call(null);
+    verify(listener).call(any());
 
     emitter.removeListener(listener);
     emitter.onStop();
@@ -137,11 +138,11 @@ public final class NaviActivityTest {
   }
 
   @Test public void destroyListener() {
-    Listener<Void> listener = mock(Listener.class);
+    Listener<Object> listener = mock(Listener.class);
     emitter.addListener(Event.DESTROY, listener);
 
     emitter.onDestroy();
-    verify(listener).call(null);
+    verify(listener).call(any());
 
     emitter.removeListener(listener);
     emitter.onDestroy();
@@ -149,11 +150,11 @@ public final class NaviActivityTest {
   }
 
   @Test public void restartListener() {
-    Listener<Void> listener = mock(Listener.class);
+    Listener<Object> listener = mock(Listener.class);
     emitter.addListener(Event.RESTART, listener);
 
     emitter.onRestart();
-    verify(listener).call(null);
+    verify(listener).call(any());
 
     emitter.removeListener(listener);
     emitter.onRestart();
@@ -238,11 +239,11 @@ public final class NaviActivityTest {
   }
 
   @Test public void backPressedListener() {
-    Listener<Void> listener = mock(Listener.class);
+    Listener<Object> listener = mock(Listener.class);
     emitter.addListener(Event.BACK_PRESSED, listener);
 
     emitter.onBackPressed();
-    verify(listener).call(null);
+    verify(listener).call(any());
 
     emitter.removeListener(listener);
     emitter.onBackPressed();
@@ -250,11 +251,11 @@ public final class NaviActivityTest {
   }
 
   @Test public void attachedToWindowListener() {
-    Listener<Void> listener = mock(Listener.class);
+    Listener<Object> listener = mock(Listener.class);
     emitter.addListener(Event.ATTACHED_TO_WINDOW, listener);
 
     emitter.onAttachedToWindow();
-    verify(listener).call(null);
+    verify(listener).call(any());
 
     emitter.removeListener(listener);
     emitter.onAttachedToWindow();
@@ -262,11 +263,11 @@ public final class NaviActivityTest {
   }
 
   @Test public void detachedFromWindowListener() {
-    Listener<Void> listener = mock(Listener.class);
+    Listener<Object> listener = mock(Listener.class);
     emitter.addListener(Event.DETACHED_FROM_WINDOW, listener);
 
     emitter.onDetachedFromWindow();
-    verify(listener).call(null);
+    verify(listener).call(any());
 
     emitter.removeListener(listener);
     emitter.onDetachedFromWindow();

--- a/navi/src/test/java/com/trello/navi2/NaviFragmentTest.java
+++ b/navi/src/test/java/com/trello/navi2/NaviFragmentTest.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import static com.trello.navi2.TestUtils.setSdkInt;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -122,11 +123,11 @@ public final class NaviFragmentTest {
   }
 
   @Test public void startListener() {
-    Listener<Void> listener = mock(Listener.class);
+    Listener<Object> listener = mock(Listener.class);
     emitter.addListener(Event.START, listener);
 
     emitter.onStart();
-    verify(listener).call(null);
+    verify(listener).call(any());
 
     emitter.removeListener(listener);
     emitter.onStart();
@@ -134,11 +135,11 @@ public final class NaviFragmentTest {
   }
 
   @Test public void resumeListener() {
-    Listener<Void> listener = mock(Listener.class);
+    Listener<Object> listener = mock(Listener.class);
     emitter.addListener(Event.RESUME, listener);
 
     emitter.onResume();
-    verify(listener).call(null);
+    verify(listener).call(any());
 
     emitter.removeListener(listener);
     emitter.onResume();
@@ -146,11 +147,11 @@ public final class NaviFragmentTest {
   }
 
   @Test public void pauseListener() {
-    Listener<Void> listener = mock(Listener.class);
+    Listener<Object> listener = mock(Listener.class);
     emitter.addListener(Event.PAUSE, listener);
 
     emitter.onPause();
-    verify(listener).call(null);
+    verify(listener).call(any());
 
     emitter.removeListener(listener);
     emitter.onPause();
@@ -158,11 +159,11 @@ public final class NaviFragmentTest {
   }
 
   @Test public void stopListener() {
-    Listener<Void> listener = mock(Listener.class);
+    Listener<Object> listener = mock(Listener.class);
     emitter.addListener(Event.STOP, listener);
 
     emitter.onStop();
-    verify(listener).call(null);
+    verify(listener).call(any());
 
     emitter.removeListener(listener);
     emitter.onStop();
@@ -170,11 +171,11 @@ public final class NaviFragmentTest {
   }
 
   @Test public void destroyViewListener() {
-    Listener<Void> listener = mock(Listener.class);
+    Listener<Object> listener = mock(Listener.class);
     emitter.addListener(Event.DESTROY_VIEW, listener);
 
     emitter.onDestroyView();
-    verify(listener).call(null);
+    verify(listener).call(any());
 
     emitter.removeListener(listener);
     emitter.onDestroyView();
@@ -184,11 +185,11 @@ public final class NaviFragmentTest {
   }
 
   @Test public void destroyListener() {
-    Listener<Void> listener = mock(Listener.class);
+    Listener<Object> listener = mock(Listener.class);
     emitter.addListener(Event.DESTROY, listener);
 
     emitter.onDestroy();
-    verify(listener).call(null);
+    verify(listener).call(any());
 
     emitter.removeListener(listener);
     emitter.onDestroy();
@@ -196,11 +197,11 @@ public final class NaviFragmentTest {
   }
 
   @Test public void detachListener() {
-    Listener<Void> listener = mock(Listener.class);
+    Listener<Object> listener = mock(Listener.class);
     emitter.addListener(Event.DETACH, listener);
 
     emitter.onDetach();
-    verify(listener).call(null);
+    verify(listener).call(any());
 
     emitter.removeListener(listener);
     emitter.onDetach();

--- a/navi/src/test/java/com/trello/navi2/NullBundleTest.java
+++ b/navi/src/test/java/com/trello/navi2/NullBundleTest.java
@@ -1,0 +1,60 @@
+package com.trello.navi2;
+
+import android.os.Bundle;
+import com.trello.navi2.internal.NaviEmitter;
+import org.junit.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class NullBundleTest {
+
+  @Test public void activityCreatedWithNullBundle() {
+    NaviEmitter emitter = NaviEmitter.createFragmentEmitter();
+    Listener<Bundle> listener = mock(Listener.class);
+    emitter.addListener(Event.ACTIVITY_CREATED, listener);
+    emitter.onActivityCreated(null);
+    verify(listener).call(any(Bundle.class));
+  }
+
+  @Test public void createWithNullBundle() {
+    NaviEmitter emitter = NaviEmitter.createActivityEmitter();
+    Listener<Bundle> listener = mock(Listener.class);
+    emitter.addListener(Event.CREATE, listener);
+    emitter.onCreate(null);
+    verify(listener).call(any(Bundle.class));
+  }
+
+  @Test public void createViewWithNullBundle() {
+    NaviEmitter emitter = NaviEmitter.createFragmentEmitter();
+    Listener<Bundle> listener = mock(Listener.class);
+    emitter.addListener(Event.CREATE_VIEW, listener);
+    emitter.onCreateView(null);
+    verify(listener).call(any(Bundle.class));
+  }
+
+  @Test public void postCreateWithNullBundle() {
+    NaviEmitter emitter = NaviEmitter.createActivityEmitter();
+    Listener<Bundle> listener = mock(Listener.class);
+    emitter.addListener(Event.POST_CREATE, listener);
+    emitter.onPostCreate(null);
+    verify(listener).call(any(Bundle.class));
+  }
+
+  @Test public void restoreInstanceStateWithNullBundle() {
+    NaviEmitter emitter = NaviEmitter.createActivityEmitter();
+    Listener<Bundle> listener = mock(Listener.class);
+    emitter.addListener(Event.RESTORE_INSTANCE_STATE, listener);
+    emitter.onRestoreInstanceState(null);
+    verify(listener).call(any(Bundle.class));
+  }
+
+  @Test public void viewStateRestoredWithNullBundle() {
+    NaviEmitter emitter = NaviEmitter.createFragmentEmitter();
+    Listener<Bundle> listener = mock(Listener.class);
+    emitter.addListener(Event.VIEW_STATE_RESTORED, listener);
+    emitter.onViewStateRestored(null);
+    verify(listener).call(any(Bundle.class));
+  }
+}

--- a/navi/src/test/java/com/trello/navi2/rx/RxNaviActivityTest.java
+++ b/navi/src/test/java/com/trello/navi2/rx/RxNaviActivityTest.java
@@ -53,7 +53,7 @@ public final class RxNaviActivityTest {
   }
 
   @Test public void observeStart() {
-    TestSubscriber<Void> testSubscriber = new TestSubscriber<>();
+    TestSubscriber<Object> testSubscriber = new TestSubscriber<>();
     Subscription subscription = RxNavi.observe(emitter, Event.START).subscribe(testSubscriber);
     testSubscriber.assertNoValues();
 
@@ -61,7 +61,7 @@ public final class RxNaviActivityTest {
     subscription.unsubscribe();
     emitter.onStart();
 
-    testSubscriber.assertValue(null);
+    testSubscriber.assertValueCount(1);
     testSubscriber.assertNoTerminalEvent();
     testSubscriber.assertUnsubscribed();
   }
@@ -100,7 +100,7 @@ public final class RxNaviActivityTest {
   }
 
   @Test public void observeResume() {
-    TestSubscriber<Void> testSubscriber = new TestSubscriber<>();
+    TestSubscriber<Object> testSubscriber = new TestSubscriber<>();
     Subscription subscription = RxNavi.observe(emitter, Event.RESUME).subscribe(testSubscriber);
     testSubscriber.assertNoValues();
 
@@ -108,13 +108,13 @@ public final class RxNaviActivityTest {
     subscription.unsubscribe();
     emitter.onResume();
 
-    testSubscriber.assertValue(null);
+    testSubscriber.assertValueCount(1);
     testSubscriber.assertNoTerminalEvent();
     testSubscriber.assertUnsubscribed();
   }
 
   @Test public void observePause() {
-    TestSubscriber<Void> testSubscriber = new TestSubscriber<>();
+    TestSubscriber<Object> testSubscriber = new TestSubscriber<>();
     Subscription subscription = RxNavi.observe(emitter, Event.PAUSE).subscribe(testSubscriber);
     testSubscriber.assertNoValues();
 
@@ -122,13 +122,13 @@ public final class RxNaviActivityTest {
     subscription.unsubscribe();
     emitter.onPause();
 
-    testSubscriber.assertValue(null);
+    testSubscriber.assertValueCount(1);
     testSubscriber.assertNoTerminalEvent();
     testSubscriber.assertUnsubscribed();
   }
 
   @Test public void observeStop() {
-    TestSubscriber<Void> testSubscriber = new TestSubscriber<>();
+    TestSubscriber<Object> testSubscriber = new TestSubscriber<>();
     Subscription subscription = RxNavi.observe(emitter, Event.STOP).subscribe(testSubscriber);
     testSubscriber.assertNoValues();
 
@@ -136,13 +136,13 @@ public final class RxNaviActivityTest {
     subscription.unsubscribe();
     emitter.onStop();
 
-    testSubscriber.assertValue(null);
+    testSubscriber.assertValueCount(1);
     testSubscriber.assertNoTerminalEvent();
     testSubscriber.assertUnsubscribed();
   }
 
   @Test public void observeDestroy() {
-    TestSubscriber<Void> testSubscriber = new TestSubscriber<>();
+    TestSubscriber<Object> testSubscriber = new TestSubscriber<>();
     Subscription subscription = RxNavi.observe(emitter, Event.DESTROY).subscribe(testSubscriber);
     testSubscriber.assertNoValues();
 
@@ -150,13 +150,13 @@ public final class RxNaviActivityTest {
     subscription.unsubscribe();
     emitter.onDestroy();
 
-    testSubscriber.assertValue(null);
+    testSubscriber.assertValueCount(1);
     testSubscriber.assertNoTerminalEvent();
     testSubscriber.assertUnsubscribed();
   }
 
   @Test public void observeRestart() {
-    TestSubscriber<Void> testSubscriber = new TestSubscriber<>();
+    TestSubscriber<Object> testSubscriber = new TestSubscriber<>();
     Subscription subscription = RxNavi.observe(emitter, Event.RESTART).subscribe(testSubscriber);
     testSubscriber.assertNoValues();
 
@@ -164,7 +164,7 @@ public final class RxNaviActivityTest {
     subscription.unsubscribe();
     emitter.onRestart();
 
-    testSubscriber.assertValue(null);
+    testSubscriber.assertValueCount(1);
     testSubscriber.assertNoTerminalEvent();
     testSubscriber.assertUnsubscribed();
   }
@@ -252,7 +252,7 @@ public final class RxNaviActivityTest {
   }
 
   @Test public void observeBackPressed() {
-    TestSubscriber<Void> testSubscriber = new TestSubscriber<>();
+    TestSubscriber<Object> testSubscriber = new TestSubscriber<>();
     Subscription subscription =
         RxNavi.observe(emitter, Event.BACK_PRESSED).subscribe(testSubscriber);
     testSubscriber.assertNoValues();
@@ -261,13 +261,13 @@ public final class RxNaviActivityTest {
     subscription.unsubscribe();
     emitter.onBackPressed();
 
-    testSubscriber.assertValue(null);
+    testSubscriber.assertValueCount(1);
     testSubscriber.assertNoTerminalEvent();
     testSubscriber.assertUnsubscribed();
   }
 
   @Test public void observeAttachedToWindow() {
-    TestSubscriber<Void> testSubscriber = new TestSubscriber<>();
+    TestSubscriber<Object> testSubscriber = new TestSubscriber<>();
     Subscription subscription =
         RxNavi.observe(emitter, Event.ATTACHED_TO_WINDOW).subscribe(testSubscriber);
     testSubscriber.assertNoValues();
@@ -276,13 +276,13 @@ public final class RxNaviActivityTest {
     subscription.unsubscribe();
     emitter.onAttachedToWindow();
 
-    testSubscriber.assertValue(null);
+    testSubscriber.assertValueCount(1);
     testSubscriber.assertNoTerminalEvent();
     testSubscriber.assertUnsubscribed();
   }
 
   @Test public void observeDetachedFromWindow() {
-    TestSubscriber<Void> testSubscriber = new TestSubscriber<>();
+    TestSubscriber<Object> testSubscriber = new TestSubscriber<>();
     Subscription subscription =
         RxNavi.observe(emitter, Event.DETACHED_FROM_WINDOW).subscribe(testSubscriber);
     testSubscriber.assertNoValues();
@@ -291,7 +291,7 @@ public final class RxNaviActivityTest {
     subscription.unsubscribe();
     emitter.onDetachedFromWindow();
 
-    testSubscriber.assertValue(null);
+    testSubscriber.assertValueCount(1);
     testSubscriber.assertNoTerminalEvent();
     testSubscriber.assertUnsubscribed();
   }

--- a/navi/src/test/java/com/trello/navi2/rx/RxNaviFragmentTest.java
+++ b/navi/src/test/java/com/trello/navi2/rx/RxNaviFragmentTest.java
@@ -119,7 +119,7 @@ public final class RxNaviFragmentTest {
   }
 
   @Test public void observeStart() {
-    TestSubscriber<Void> testSubscriber = new TestSubscriber<>();
+    TestSubscriber<Object> testSubscriber = new TestSubscriber<>();
     Subscription subscription = RxNavi.observe(emitter, Event.START).subscribe(testSubscriber);
     testSubscriber.assertNoValues();
 
@@ -127,13 +127,13 @@ public final class RxNaviFragmentTest {
     subscription.unsubscribe();
     emitter.onStart();
 
-    testSubscriber.assertValue(null);
+    testSubscriber.assertValueCount(1);
     testSubscriber.assertNoTerminalEvent();
     testSubscriber.assertUnsubscribed();
   }
 
   @Test public void observeResume() {
-    TestSubscriber<Void> testSubscriber = new TestSubscriber<>();
+    TestSubscriber<Object> testSubscriber = new TestSubscriber<>();
     Subscription subscription = RxNavi.observe(emitter, Event.RESUME).subscribe(testSubscriber);
     testSubscriber.assertNoValues();
 
@@ -141,13 +141,13 @@ public final class RxNaviFragmentTest {
     subscription.unsubscribe();
     emitter.onResume();
 
-    testSubscriber.assertValue(null);
+    testSubscriber.assertValueCount(1);
     testSubscriber.assertNoTerminalEvent();
     testSubscriber.assertUnsubscribed();
   }
 
   @Test public void observePause() {
-    TestSubscriber<Void> testSubscriber = new TestSubscriber<>();
+    TestSubscriber<Object> testSubscriber = new TestSubscriber<>();
     Subscription subscription = RxNavi.observe(emitter, Event.PAUSE).subscribe(testSubscriber);
     testSubscriber.assertNoValues();
 
@@ -155,13 +155,13 @@ public final class RxNaviFragmentTest {
     subscription.unsubscribe();
     emitter.onPause();
 
-    testSubscriber.assertValue(null);
+    testSubscriber.assertValueCount(1);
     testSubscriber.assertNoTerminalEvent();
     testSubscriber.assertUnsubscribed();
   }
 
   @Test public void observeStop() {
-    TestSubscriber<Void> testSubscriber = new TestSubscriber<>();
+    TestSubscriber<Object> testSubscriber = new TestSubscriber<>();
     Subscription subscription = RxNavi.observe(emitter, Event.STOP).subscribe(testSubscriber);
     testSubscriber.assertNoValues();
 
@@ -169,13 +169,13 @@ public final class RxNaviFragmentTest {
     subscription.unsubscribe();
     emitter.onStop();
 
-    testSubscriber.assertValue(null);
+    testSubscriber.assertValueCount(1);
     testSubscriber.assertNoTerminalEvent();
     testSubscriber.assertUnsubscribed();
   }
 
   @Test public void observeDestroyView() {
-    TestSubscriber<Void> testSubscriber = new TestSubscriber<>();
+    TestSubscriber<Object> testSubscriber = new TestSubscriber<>();
     Subscription subscription = RxNavi.observe(emitter, Event.DESTROY_VIEW).subscribe(testSubscriber);
     testSubscriber.assertNoValues();
 
@@ -183,13 +183,13 @@ public final class RxNaviFragmentTest {
     subscription.unsubscribe();
     emitter.onDestroyView();
 
-    testSubscriber.assertValue(null);
+    testSubscriber.assertValueCount(1);
     testSubscriber.assertNoTerminalEvent();
     testSubscriber.assertUnsubscribed();
   }
 
   @Test public void observeDestroy() {
-    TestSubscriber<Void> testSubscriber = new TestSubscriber<>();
+    TestSubscriber<Object> testSubscriber = new TestSubscriber<>();
     Subscription subscription = RxNavi.observe(emitter, Event.DESTROY).subscribe(testSubscriber);
     testSubscriber.assertNoValues();
 
@@ -197,13 +197,13 @@ public final class RxNaviFragmentTest {
     subscription.unsubscribe();
     emitter.onDestroy();
 
-    testSubscriber.assertValue(null);
+    testSubscriber.assertValueCount(1);
     testSubscriber.assertNoTerminalEvent();
     testSubscriber.assertUnsubscribed();
   }
 
   @Test public void observeDetach() {
-    TestSubscriber<Void> testSubscriber = new TestSubscriber<>();
+    TestSubscriber<Object> testSubscriber = new TestSubscriber<>();
     Subscription subscription = RxNavi.observe(emitter, Event.DETACH).subscribe(testSubscriber);
     testSubscriber.assertNoValues();
 
@@ -211,7 +211,7 @@ public final class RxNaviFragmentTest {
     subscription.unsubscribe();
     emitter.onDetach();
 
-    testSubscriber.assertValue(null);
+    testSubscriber.assertValueCount(1);
     testSubscriber.assertNoTerminalEvent();
     testSubscriber.assertUnsubscribed();
   }

--- a/sample/src/main/java/com/trello/navi2/sample/MainActivity.java
+++ b/sample/src/main/java/com/trello/navi2/sample/MainActivity.java
@@ -36,8 +36,8 @@ public class MainActivity extends NaviAppCompatActivity {
 
     // Counter that operates on screen only while resumed; automatically ends itself on destroy
     RxNavi.observe(naviComponent, Event.RESUME)
-        .flatMap(new Func1<Void, Observable<Long>>() {
-          @Override public Observable<Long> call(Void v) {
+        .flatMap(new Func1<Object, Observable<Long>>() {
+          @Override public Observable<Long> call(Object v) {
             return Observable.interval(1, TimeUnit.SECONDS)
                 .takeUntil(RxNavi.observe(naviComponent, Event.PAUSE));
           }


### PR DESCRIPTION
RxJava 2 does not allow emitting nulls anymore, so we must disallow it as well.