### PR TITLE
RxNavi: Fail early on null component or event.

### DIFF
--- a/navi/src/main/java/com/trello/navi2/rx/RxNavi.java
+++ b/navi/src/main/java/com/trello/navi2/rx/RxNavi.java
@@ -24,6 +24,8 @@ public final class RxNavi {
 
   @CheckResult @NonNull
   public static <T> Observable<T> observe(@NonNull NaviComponent component, @NonNull Event<T> event) {
+    if (component == null) throw new IllegalArgumentException("component == null");
+    if (event == null) throw new IllegalArgumentException("event == null");
     return Observable.create(new NaviOnSubscribe<>(component, event));
   }
 


### PR DESCRIPTION
Also would you consider making `2.x` the default branch? Given that 1.x is EOL.

Fixes #95 